### PR TITLE
chore: prepare default branch rename

### DIFF
--- a/.agents/memory/MEMORY.md
+++ b/.agents/memory/MEMORY.md
@@ -20,7 +20,7 @@ canonical store は repo 内 `.agents/memory/`。agent 固有の自動 memory �
 
 ### In Progress
 
-- [ ] **#8 `master` -> `main` rename** — 2026-05-20 更新 / `chore/master-to-main-rename` で repo 内表記を `develop` 向けに更新済み。remote `main` は `origin/master` と同じ `949fd18` で作成済み。GitHub default branch は `main` に変更済み。local `origin/HEAD` も `origin/main` に更新済み。local `master` は削除済み。remote `master` deletion / `main` への PR・merge は未実行であり、各操作前に明示確認する。
+- [ ] **#8 `master` -> `main` rename** — 2026-05-20 更新 / `chore/master-to-main-rename` で repo 内表記を `develop` 向けに更新し、PR #5 を `develop` 向けに作成済み。remote `main` は `origin/master` と同じ `949fd18` で作成済み。GitHub default branch は `main` に変更済み。local `origin/HEAD` も `origin/main` に更新済み。local `master` は削除済み。remote `master` deletion / `main` への PR・merge は未実行であり、各操作前に明示確認する。
 
 ### Backlog
 

--- a/.agents/memory/MEMORY.md
+++ b/.agents/memory/MEMORY.md
@@ -20,13 +20,11 @@ canonical store は repo 内 `.agents/memory/`。agent 固有の自動 memory �
 
 ### In Progress
 
-なし。
+- [ ] **#8 `master` -> `main` rename** — 2026-05-20 更新 / `chore/master-to-main-rename` で repo 内表記を `develop` 向けに更新済み。remote `main` は `origin/master` と同じ `949fd18` で作成済み。GitHub default branch は `main` に変更済み。local `origin/HEAD` も `origin/main` に更新済み。local `master` は削除済み。remote `master` deletion / `main` への PR・merge は未実行であり、各操作前に明示確認する。
 
 ### Backlog
 
-- [ ] **#6 PR #4 merge** — 2026-05-20 更新 / CI pass 後、PR #4 を `develop` へ merge。
 - [ ] **#7 Example 挙動不具合修正** — 2026-05-20 更新 / 新規セッションで対応。Simulator / 実機確認を必須 gate にする。
-- [ ] **#8 `master` -> `main` rename** — 2026-05-20 更新 / 別作業。GitHub default branch、branch protection、CI `push.branches`、guide 表記を更新。
 
 ### Icebox
 
@@ -38,6 +36,7 @@ canonical store は repo 内 `.agents/memory/`。agent 固有の自動 memory �
 
 ### Done
 
+- [x] **#6 PR #4 merge** — 2026-05-20 / PR #4 を `develop` へ squash merge。merge commit `7ebb9e3`。`build/xcode26-spm-migration` は local / remote とも削除済み。
 - [x] **#5 PR #4 CI simulator destination 修正** — 2026-05-20 / `fastlane/ios_simulator_destination.rb` で available simulator を動的選択し、CI は runner に installed simulator がある Xcode 26.4.1 を使用。PR #4 の CI `test` と Hound は pass。
 - [x] **#1 Repository guidelines 初期作成** — 2026-05-19 / agent entrypoint、`CODING-GUIDE.md`、project memory を作成。
 - [x] **#2 Xcode 26 SPM migration** — 2026-05-19 / Xcode 26.5, iOS 15 minimum, SPM, mise, fastlane 整理。

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
   push:
     branches:
-      - master
+      - main
 
 permissions:
   contents: read

--- a/CODING-GUIDE.md
+++ b/CODING-GUIDE.md
@@ -185,11 +185,11 @@ commit message は Conventional Commits 寄りにする。例: `docs: add agent 
 
 通常 task は `develop` から作業ブランチを切る。`develop` で直接作業しない。小さな docs 修正でも、ユーザーが直接 commit を明示しない限りブランチを提案する。
 
-作業完了後の PR / merge target は原則 `develop`。まとまった更新が完了し、version up / release 公開を行う段階でのみ `master` に merge する。`master` は公開済みまたは公開準備済みの状態を保つ。
+作業完了後の PR / merge target は原則 `develop`。まとまった更新が完了し、version up / release 公開を行う段階でのみ `main` に merge する。`main` は公開済みまたは公開準備済みの状態を保つ。
 
-`master` は現時点の release / public branch 名である。`master` -> `main` rename task が完了したら、本 guide の `master` 表記も同時に `main` へ更新する。
+`main` は release / public branch 名である。`main` への PR / merge は公開処理が走る可能性があるため、通常 task では行わない。
 
-作業ブランチ -> `develop` は squash merge を基本とする。`develop` -> `master` は release 境界を残すため merge commit を基本とする。
+作業ブランチ -> `develop` は squash merge を基本とする。`develop` -> `main` は release 境界を残すため merge commit を基本とする。
 
 branch prefix は `docs/`, `feature/`, `fix/`, `improve/`, `perf/`, `refactor/`, `upgrade/`, `build/`, `chore/` のいずれかを優先する。ブランチ名は候補を複数提示し、ユーザー承諾後に作成する。ブランチ作成後もすぐに実装に入らず、作業内容と方針をユーザーに確認してから着手する。
 
@@ -214,7 +214,7 @@ branch deletion は、completion flow の一括承認があっても自動実行
 - checks failed を確認した。
 - unrelated な dirty worktree。
 - protected branch / permission / GitHub 側 error。
-- `develop` / `master` へ直接 commit が必要になりそうな場合。
+- `develop` / `main` へ直接 commit が必要になりそうな場合。
 
 ### PR Checks / Merge Gate
 
@@ -224,7 +224,7 @@ PR 作成後の checks / merge は base branch ごとに扱いを分ける。
 
 checks が pending の場合は状態を報告して待機または停止する。checks が failed の場合は default では merge せず、failure 内容を報告する。ユーザーが `checks を無視して merge` / `このまま merge` 等で明示的に指示した場合のみ、現在の checks 状態を再報告した上で merge してよい。
 
-`develop` から `master` への PR は release / public 境界であるため、required checks を待機する。checks が pass し、ユーザーが merge を承認したら、`master` へ merge commit で統合する。
+`develop` から `main` への PR は release / public 境界であるため、required checks を待機する。checks が pass し、ユーザーが merge を承認したら、`main` へ merge commit で統合する。
 
 checks polling 中にユーザーから新しい指示が来た場合、その指示を優先する。`status` 要求なら現在の checks 状態を返して polling を継続する。`merge` 指示なら checks 状態を再確認し、上記の明示 merge 指示として扱う。
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 [![CI](https://github.com/gumob/Fluidable/actions/workflows/ci.yml/badge.svg)](https://github.com/gumob/Fluidable/actions/workflows/ci.yml)
-[![codecov](https://codecov.io/gh/gumob/Fluidable/branch/master/graph/badge.svg)](https://codecov.io/gh/gumob/Fluidable)
+[![codecov](https://codecov.io/gh/gumob/Fluidable/branch/main/graph/badge.svg)](https://codecov.io/gh/gumob/Fluidable)
 [![Reviewed by Hound](https://img.shields.io/badge/Reviewed_by-Hound-8E64B0.svg)](https://houndci.com)
 ![Language](https://img.shields.io/badge/Language-Swift%205-orange.svg)
 ![Packagist](https://img.shields.io/packagist/l/doctrine/orm.svg)
@@ -41,13 +41,13 @@ dependencies: [
 ```
 
 ## Example application
-Repository contains example sources under [Example](https://github.com/gumob/Fluidable/tree/master/Example) directory. Structure of the application is simple, but the project contains mutiple case of UI petterns to showcase capabilities of the library.
+Repository contains example sources under [Example](https://github.com/gumob/Fluidable/tree/main/Example) directory. Structure of the application is simple, but the project contains mutiple case of UI petterns to showcase capabilities of the library.
 You can build an example app by choosing `FluidableExample` from the Xcode schemes.
 
 ## Usage
 
 Full documentation is available at [https://gumob.github.io/Fluidable/documentation/fluidable/](https://gumob.github.io/Fluidable/documentation/fluidable/).<br/>
-You can find more specific implementations by searching the [Example](https://github.com/gumob/Fluidable/tree/master/Example) sources with "`IMPORTANT: 🌊`".
+You can find more specific implementations by searching the [Example](https://github.com/gumob/Fluidable/tree/main/Example) sources with "`IMPORTANT: 🌊`".
 
 
 ### Custom transition using [`UIViewControllerTransitioningDelegate`](https://developer.apple.com/documentation/uikit/uiviewcontrollertransitioningdelegate)


### PR DESCRIPTION
Summary: update repo-local references from master to main for CI, README, branch workflow docs, and project memory. Verification: git diff --check HEAD~1 HEAD; reviewed remaining master references; confirmed GitHub default branch is main and origin/HEAD points to origin/main. Notes: target is develop only; no PR or merge to main; remote master deletion is intentionally out of scope.