### PR TITLE
docs: clarify memory update timing

### DIFF
--- a/.agents/memory/MEMORY.md
+++ b/.agents/memory/MEMORY.md
@@ -20,7 +20,7 @@ canonical store は repo 内 `.agents/memory/`。agent 固有の自動 memory �
 
 ### In Progress
 
-- [ ] **#8 `master` -> `main` rename** — 2026-05-20 更新 / `chore/master-to-main-rename` で repo 内表記を `develop` 向けに更新し、PR #5 を `develop` 向けに作成済み。remote `main` は `origin/master` と同じ `949fd18` で作成済み。GitHub default branch は `main` に変更済み。local `origin/HEAD` も `origin/main` に更新済み。local `master` は削除済み。remote `master` deletion / `main` への PR・merge は未実行であり、各操作前に明示確認する。
+なし。
 
 ### Backlog
 
@@ -36,6 +36,7 @@ canonical store は repo 内 `.agents/memory/`。agent 固有の自動 memory �
 
 ### Done
 
+- [x] **#8 `master` -> `main` rename** — 2026-05-20 / repo 内表記を `develop` 向けに更新し、PR #5 を `develop` へ squash merge。merge commit `8a30ed5`。GitHub default branch は `main` に変更済み。local / remote `master` は削除済み。`main` への PR・merge は未実行。
 - [x] **#6 PR #4 merge** — 2026-05-20 / PR #4 を `develop` へ squash merge。merge commit `7ebb9e3`。`build/xcode26-spm-migration` は local / remote とも削除済み。
 - [x] **#5 PR #4 CI simulator destination 修正** — 2026-05-20 / `fastlane/ios_simulator_destination.rb` で available simulator を動的選択し、CI は runner に installed simulator がある Xcode 26.4.1 を使用。PR #4 の CI `test` と Hound は pass。
 - [x] **#1 Repository guidelines 初期作成** — 2026-05-19 / agent entrypoint、`CODING-GUIDE.md`、project memory を作成。

--- a/CODING-GUIDE.md
+++ b/CODING-GUIDE.md
@@ -332,8 +332,10 @@ memory file は file 種別ごとに commit timing を分ける。
 | --- | --- | --- |
 | `gotcha_*.md` / `feedback_*.md` の新規追加 | 作業ブランチで PR 前 commit、PR に含める | 永続的な技術知見・ユーザー規律で PR # / merge SHA に依存しない。 |
 | `project_*.md` の進行中 task 状態更新 | 作業ブランチに含める | task 中で書いた中間記録であり、作業ブランチが自然な置き場。 |
-| `MEMORY.md` の該当 task 完了チェック (`[ ]` -> `[x]`) | 作業ブランチで PR 前 commit、PR に含める | ブランチ task は memory の task list 更新まで含めて完了扱いにする。 |
-| `MEMORY.md` Done section への PR # / merge SHA 追記 | merge 後に小ブランチを切り、PR 経由で反映する | PR # / merge SHA は merge 後しか確定しない。`develop` / release branch で直接作業しない。 |
+| `MEMORY.md` の task registry 更新 (`In Progress` / `Backlog` / `Done` 移動、確定済み task 状態) | 原則として作業ブランチで PR 前 commit、PR に含める | ブランチ task は memory の task list 更新まで含めて完了扱いにする。 |
+| `MEMORY.md` Done section への PR # / merge SHA / branch deletion / remote rename 等の merge 後にしか確定しない事実追記 | 原則として merge 後に小ブランチを切り、PR 経由で反映する | PR # / merge SHA / branch deletion / remote rename は merge 後または後続操作後に確定する。 |
+
+例外として、`MEMORY.md` の task registry correction だけを更新し、code / CI / project policy / public docs / spec / plan を一切含まない場合に限り、ユーザー明示承認があれば現在の integration branch (`develop` など) へ直接小 commit してよい。この例外でも `git diff --check`、対象 diff の目視、Commit Gate は必須とする。unrelated dirty worktree がある場合は停止する。
 
 ### Task Registry / Memory Backlog Policy
 


### PR DESCRIPTION
Summary: clarify when MEMORY.md task registry updates belong in a task branch and when merge-only facts should be reflected later. Mark #8 master to main rename complete after PR #5 merge, default branch switch, and local/remote master deletion. Verification: git diff --check HEAD~1 HEAD. Notes: target is develop only; no PR or merge to main.