### PR TITLE
Specify Ruby for Pages workflow

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -27,6 +27,7 @@ jobs:
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
+          ruby-version: ruby
           bundler-cache: true
 
       - name: Select Xcode


### PR DESCRIPTION
## Summary
- specify Ruby for ruby/setup-ruby in the Pages workflow
- fix the failed Pages run caused by missing .ruby-version/.tool-versions/mise.toml

## Verification
- git diff --check
- Ruby YAML parse for .github/workflows/pages.yml

## Notes
- Uses ruby-version: ruby, the stable MRI selector supported by ruby/setup-ruby.
- No version tag is created.
