### PR TITLE
Sync Pages Ruby fix into main

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -27,6 +27,7 @@ jobs:
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
+          ruby-version: ruby
           bundler-cache: true
 
       - name: Select Xcode


### PR DESCRIPTION
## Summary
- sync the Pages workflow Ruby version fix from develop into main
- fixes the failed Pages run caused by ruby/setup-ruby missing ruby-version

## Notes
- This PR does not create or push a git tag, so it does not bump the SwiftPM version.
- After merge, the Pages workflow should rerun from main and publish https://gumob.github.io/Fluidable/.

## Verification
- PR #12 merged into develop
- Hound passed on PR #12
- Local git diff --check and YAML parse passed before PR #12
