### PR TITLE
fix: let Codecov discover Swift coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,9 +54,7 @@ jobs:
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v6
         with:
-          disable_search: true
           fail_ci_if_error: true
-          files: Reports/coverage/xccov.txt
           flags: unittests
           name: Fluidable
           swift_project: Fluidable


### PR DESCRIPTION
## Summary
- remove explicit xccov.txt upload from the Codecov action
- keep Codecov OIDC auth and swift_project coverage generation enabled
- keep xccov.txt export for local inspection

## Verification
- git diff --check
- YAML step inspection

## Follow-up verification
- PR CI Codecov step should pass
- Codecov API should report files and coverage greater than zero for this commit