### PR TITLE
ci: update Pages actions for Node 24

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -40,16 +40,16 @@ jobs:
           xcodebuild -showsdks
 
       - name: Set up Pages
-        uses: actions/configure-pages@v5
+        uses: actions/configure-pages@v6
 
       - name: Generate DocC site
         run: DOCC_HOSTING_BASE_PATH=Fluidable bundle exec fastlane ios create_doc
 
       - name: Upload Pages artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
         with:
           path: docs
 
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5


### PR DESCRIPTION
## Summary
- update GitHub Pages actions to Node 24-compatible major versions
- avoid the Node.js 20 deprecation warning in future Pages deployments

## Verification
- confirmed the latest Pages run warning listed actions/configure-pages@v5, actions/deploy-pages@v4, and upload-artifact@v4 via upload-pages-artifact@v3
- confirmed configure-pages@v6 and deploy-pages@v5 use node24
- confirmed upload-pages-artifact@v5 uses upload-artifact@v7, which uses node24
- ran git diff --check
- parsed .github/workflows/pages.yml with Ruby YAML