### PR TITLE
fix(ui-tests): restore interactive dismiss rotation

### DIFF
--- a/Fluidable.xcodeproj/project.pbxproj
+++ b/Fluidable.xcodeproj/project.pbxproj
@@ -32,6 +32,7 @@
 		A73FA6062228373D00B9B993 /* HeaderView.xib in Resources */ = {isa = PBXBuildFile; fileRef = A73FA6042228373D00B9B993 /* HeaderView.xib */; };
 		A743D1CC21C7A17F00230502 /* Fluidable.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A71F674521C50EA8007CADA0 /* Fluidable.framework */; };
 		A743D1CD21C7A17F00230502 /* Fluidable.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = A71F674521C50EA8007CADA0 /* Fluidable.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		A743D1CF21C7A17F00230502 /* Fluidable.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = A71F674521C50EA8007CADA0 /* Fluidable.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		A7498D3A22B0F474002282DD /* NavigationChildViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DFABE81DB86B266033ED2C1C /* NavigationChildViewController.swift */; };
 		A74ACA1822F01513009BF25C /* Debug.swift in Sources */ = {isa = PBXBuildFile; fileRef = A77D9F0D22F0119E0071867E /* Debug.swift */; };
 		A74ACA1922F01513009BF25C /* Debug.swift in Sources */ = {isa = PBXBuildFile; fileRef = A77D9F0D22F0119E0071867E /* Debug.swift */; };
@@ -327,6 +328,17 @@
 			dstSubfolderSpec = 10;
 			files = (
 				A743D1CD21C7A17F00230502 /* Fluidable.framework in Embed Frameworks */,
+			);
+			name = "Embed Frameworks";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		A743D1D021C7A17F00230502 /* Embed Frameworks */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 10;
+			files = (
+				A743D1CF21C7A17F00230502 /* Fluidable.framework in Embed Frameworks */,
 			);
 			name = "Embed Frameworks";
 			runOnlyForDeploymentPostprocessing = 0;
@@ -1273,6 +1285,7 @@
 			buildPhases = (
 				A71F680321C6624A007CADA0 /* Sources */,
 				A71F680421C6624A007CADA0 /* Frameworks */,
+				A743D1D021C7A17F00230502 /* Embed Frameworks */,
 				A71F680521C6624A007CADA0 /* Resources */,
 			);
 			buildRules = (

--- a/UITests/MainSpec.swift
+++ b/UITests/MainSpec.swift
@@ -76,10 +76,7 @@ final class MainSpec: QuickSpec {
                         /* Fixed */
                         it("FinishAnimatedPresent_FinishInteractiveDismiss") {
                             self.finishAnimatedPresent(app: app, orientation: orientation, model: model)
-                            // These cases lose stable scroll targets after rotation on current iOS simulator runtimes.
-                            if !self.shouldSkipRotationDuringInteractiveDismiss(model: model) {
-                                self.rotateAndRevertDevice(app: app, orientation: orientation, model: model)
-                            }
+                            self.rotateAndRevertDevice(app: app, orientation: orientation, model: model)
                             self.scrollToDismissiblePosition(app: app, orientation: orientation, model: model)
                             self.finishInteractiveDismiss(app: app, orientation: orientation, model: model)
                         }
@@ -146,13 +143,4 @@ final class MainSpec: QuickSpec {
         }
     }
 
-    static func shouldSkipRotationDuringInteractiveDismiss(model: RootModel) -> Bool {
-        switch model {
-        case .navigationDrawerTop,
-             .transitionSlideRight:
-            return true
-        default:
-            return false
-        }
-    }
 }


### PR DESCRIPTION
## Summary
- remove the stale UI test skip around rotation during interactive dismiss
- embed Fluidable.framework in the UI test bundle so real-device UI tests can load @testable import Fluidable

## Verification
- iPad Air 4 / iPadOS 26.5 real device: NavigationDrawerTop and TransitionSlideRight targeted UI tests passed
- iOS 26.5 Simulator: NavigationDrawerTop and TransitionSlideRight targeted UI tests passed
- iOS 26.4.1 Simulator: NavigationDrawerTop and TransitionSlideRight targeted UI tests passed
- git diff --check