### PR TITLE
#19 Improve Codecov coverage with targeted tests

### DIFF
--- a/Tests/AnimatorSpec.swift
+++ b/Tests/AnimatorSpec.swift
@@ -472,6 +472,74 @@ final class AnimatorSpec: QuickSpec {
                     expect(animator.animatorState).to(equal(.finished))
                     expect(animator.displayLink).to(beNil())
                 }
+
+                it("initializes timing variants and queued animations") {
+                    var invokedCount = 0
+                    let curveAnimator = FluidPropertyAnimator(duration: 1, curve: .easeInOut, id: "property-curve") {
+                        invokedCount += 1
+                    }
+                    let pointAnimator = FluidPropertyAnimator(duration: 1,
+                                                             controlPoint1: CGPoint(x: 0.2, y: 0.1),
+                                                             controlPoint2: CGPoint(x: 0.8, y: 0.9),
+                                                             id: "property-point") {
+                        invokedCount += 1
+                    }
+                    let scalarAnimator = FluidPropertyAnimator(duration: 1,
+                                                              c1x: 0.1,
+                                                              c1y: 0.2,
+                                                              c2x: 0.8,
+                                                              c2y: 0.9)
+                    let dampingAnimator = FluidPropertyAnimator(duration: 1, dampingRatio: 0.6, id: "property-damping") {
+                        invokedCount += 1
+                    }
+
+                    expect(curveAnimator.identifier).to(equal("property-curve"))
+                    expect(pointAnimator.identifier).to(equal("property-point"))
+                    expect(dampingAnimator.identifier).to(equal("property-damping"))
+                    expect(scalarAnimator.duration).to(equal(1))
+                    expect(curveAnimator.animations?.count).to(equal(1))
+                    expect(pointAnimator.animations?.count).to(equal(1))
+                    expect(dampingAnimator.animations?.count).to(equal(1))
+
+                    [curveAnimator, pointAnimator, scalarAnimator, dampingAnimator].forEach {
+                        $0.add({}, lazy: true)
+                        $0.run()
+                        $0.finish(at: .current)
+                        expect($0.animatorState).to(equal(.finished))
+                    }
+                    expect(invokedCount).to(equal(3))
+                }
+
+                it("converts and merges queued property animations") {
+                    let first = FluidPropertyAnimator(duration: 1, easing: .linear, id: "property-first")
+                    let second = FluidPropertyAnimator(duration: 1, easing: .easeOut, id: "property-second")
+                    let empty = FluidPropertyAnimator(duration: 1, easing: .easeIn, id: "property-empty")
+
+                    first.add({}, lazy: true)
+                    second.add({}, delayFactor: 0.2, lazy: true)
+
+                    let converted = FluidPropertyAnimator.convert([first, second, empty],
+                                                                 duration: 1,
+                                                                 easing: .linear,
+                                                                 id: "converted-property")
+                    let emptyConverted = FluidPropertyAnimator.convert(nil,
+                                                                      duration: 1,
+                                                                      easing: .linear,
+                                                                      id: "empty-converted-property")
+                    let merged = FluidPropertyAnimator.merge([first, second, empty],
+                                                            duration: 1,
+                                                            easing: .linear)
+                    let emptyMerged = FluidPropertyAnimator.merge(nil,
+                                                                 duration: 1,
+                                                                 easing: .linear)
+
+                    expect(converted.identifier).to(equal("converted-property"))
+                    expect(emptyConverted.identifier).to(equal("empty-converted-property"))
+                    expect(merged.identifier).to(equal("interruptible"))
+                    expect(emptyMerged.identifier).to(equal("interruptible"))
+                    expect(merged.animations).notTo(beNil())
+                    expect(emptyMerged.animations).notTo(beNil())
+                }
             }
         }
 

--- a/Tests/AnimatorSpec.swift
+++ b/Tests/AnimatorSpec.swift
@@ -541,6 +541,55 @@ final class AnimatorSpec: QuickSpec {
                     expect(emptyMerged.animations).notTo(beNil())
                 }
             }
+            describe("FluidInterruptibleAnimator") {
+                it("controls animation state and clears completion callbacks") {
+                    let view = UIView(frame: CGRect(x: 0, y: 0, width: 10, height: 10))
+                    let animator = FluidInterruptibleAnimator(duration: 1,
+                                                             timingParameters: FluidAnimatorEasing.linear.timingParameters,
+                                                             id: "interruptible-core")
+                    var completionPositions: [UIViewAnimatingPosition] = []
+                    var completionStates: [UIViewAnimatingStateEx] = []
+
+                    animator.addAnimations { view.alpha = 0.2 }
+                    animator.addCompletion { position, state in
+                        completionPositions.append(position)
+                        completionStates.append(state)
+                    }
+
+                    expect(animator.identifier).to(equal("interruptible-core"))
+                    expect(animator.completionBlock).notTo(beNil())
+
+                    animator.startAnimation()
+                    animator.pauseAnimation()
+                    animator.continueAnimation(withTimingParameters: FluidAnimatorEasing.easeOut.timingParameters,
+                                               durationFactor: 0.5)
+                    animator.stopAnimation(false)
+                    animator.finishAnimation(at: .end)
+
+                    expect(view.alpha).to(beCloseTo(0.2, within: 0.001))
+                    expect(completionPositions).to(contain(.end))
+                    expect(completionStates).notTo(beEmpty())
+
+                    animator.positionDidChange(position: .current)
+                    expect(completionPositions.last).to(equal(.current))
+
+                    animator.invalidate()
+                    expect(animator.completionBlock).to(beNil())
+                }
+
+                it("starts delayed animations") {
+                    let animator = FluidInterruptibleAnimator(duration: 1,
+                                                             timingParameters: FluidAnimatorEasing.linear.timingParameters,
+                                                             id: "interruptible-delayed")
+
+                    animator.addAnimations {}
+                    animator.startAnimation(afterDelay: 0)
+                    animator.stopAnimation(true)
+
+                    expect(animator.identifier).to(equal("interruptible-delayed"))
+                    animator.invalidate()
+                }
+            }
         }
 
         func calculate(easing: PennerEasing, step: CGFloat = 0.01, duration: CGFloat = 1.0, begin: CGFloat = 0.0, end: CGFloat = 100.0) -> CGFloat {

--- a/Tests/AnimatorSpec.swift
+++ b/Tests/AnimatorSpec.swift
@@ -386,6 +386,93 @@ final class AnimatorSpec: QuickSpec {
                     expect(String(describing: FluidAnimatorState.finished)).to(beginWith("finished"))
                 }
             }
+            describe("FluidPropertyAnimator") {
+                it("runs, pauses, updates, resumes, stops, and invalidates queued animations") {
+                    let view = UIView(frame: CGRect(x: 0, y: 0, width: 10, height: 10))
+                    var progressValues: [CGFloat] = []
+                    var stateValues: [FluidAnimatorState] = []
+                    let animator = FluidPropertyAnimator(duration: 1, easing: .linear, id: "property-core")
+
+                    animator
+                        .add({ view.alpha = 0.5 }, lazy: true)
+                        .add({ view.frame.origin.x = 12 }, delayFactor: 0.2, lazy: true)
+                        .on { progress in
+                            progressValues.append(progress)
+                        }
+                        .on { state, progress in
+                            stateValues.append(state)
+                            progressValues.append(progress)
+                        }
+                        .fractionComplete(0.25)
+                        .isReversed(true)
+                        .isInterruptible(false)
+                        .isUserInteractionEnabled(false)
+                        .isManualHitTestingEnabled(false)
+
+                    if #available(iOS 11.0, *) {
+                        animator.scrubsLinearly(true).pausesOnCompletion(true)
+                        expect(animator.scrubsLinearly).to(beTrue())
+                        expect(animator.pausesOnCompletion).to(beTrue())
+                        animator.configure(scrubsLinearly: false, pausesOnCompletion: false)
+                        expect(animator.scrubsLinearly).to(beFalse())
+                        expect(animator.pausesOnCompletion).to(beFalse())
+                    }
+
+                    animator.configure(isInterruptible: true,
+                                       isUserInteractionEnabled: true,
+                                       isManualHitTestingEnabled: true)
+
+                    expect(animator.identifier).to(equal("property-core"))
+                    expect(animator.animations?.count).to(equal(2))
+                    expect(animator.isInterruptible).to(beTrue())
+                    expect(animator.isUserInteractionEnabled).to(beTrue())
+                    expect(animator.isManualHitTestingEnabled).to(beTrue())
+                    expect(progressValues).notTo(beEmpty())
+
+                    animator.run()
+                    animator.add({ view.alpha = 0.25 }, lazy: true)
+                    expect(animator.animatorState).to(equal(.running))
+                    expect(animator.displayLink).notTo(beNil())
+
+                    animator.pause()
+                    expect(animator.animatorState).to(equal(.paused))
+                    expect(animator.displayLink).to(beNil())
+
+                    animator.update(fractionComplete: 0.4)
+                    expect(animator.fractionComplete).to(beCloseTo(0.4, within: 0.001))
+                    expect(animator.animatorProgress).to(beCloseTo(0.4, within: 0.001))
+
+                    animator.resume(easing: .easeOutQuad, durationFactor: 0.5)
+                    expect(animator.animatorState).to(equal(.running))
+                    expect(animator.displayLink).notTo(beNil())
+
+                    animator.stop(true)
+                    expect(animator.animatorState).to(equal(.cancelled))
+                    expect(animator.displayLink).to(beNil())
+
+                    animator.invalidate()
+                    expect(animator.animations).to(beNil())
+                    let stateDescriptions = stateValues.map { String(describing: $0) }
+                    expect(stateDescriptions).to(contain("running"))
+                    expect(stateDescriptions).to(contain("paused"))
+                    expect(stateDescriptions).to(contain("cancelled"))
+                }
+
+                it("finishes active animations and clears timers") {
+                    let animator = FluidPropertyAnimator(duration: 1, easing: .linear, id: "property-finish")
+
+                    animator.add({}, lazy: true)
+                    animator.run()
+
+                    expect(animator.animatorState).to(equal(.running))
+                    expect(animator.displayLink).notTo(beNil())
+
+                    animator.finish(at: .current)
+
+                    expect(animator.animatorState).to(equal(.finished))
+                    expect(animator.displayLink).to(beNil())
+                }
+            }
         }
 
         func calculate(easing: PennerEasing, step: CGFloat = 0.01, duration: CGFloat = 1.0, begin: CGFloat = 0.0, end: CGFloat = 100.0) -> CGFloat {

--- a/Tests/AnimatorSpec.swift
+++ b/Tests/AnimatorSpec.swift
@@ -386,6 +386,169 @@ final class AnimatorSpec: QuickSpec {
                     expect(String(describing: FluidAnimatorState.finished)).to(beginWith("finished"))
                 }
             }
+            describe("FluidCoreAnimatorKey") {
+                it("maps layer keys to Core Animation key paths") {
+                    let keyPaths: [(actual: String, expected: String)] = [
+                        (FluidCoreAnimatorKey.anchorPoint.rawValue, #keyPath(CALayer.anchorPoint)),
+                        (FluidCoreAnimatorKey.backgroundColor.rawValue, #keyPath(CALayer.backgroundColor)),
+                        (FluidCoreAnimatorKey.borderColor.rawValue, #keyPath(CALayer.borderColor)),
+                        (FluidCoreAnimatorKey.borderWidth.rawValue, #keyPath(CALayer.borderWidth)),
+                        (FluidCoreAnimatorKey.bounds.rawValue, #keyPath(CALayer.bounds)),
+                        (FluidCoreAnimatorKey.contents.rawValue, #keyPath(CALayer.contents)),
+                        (FluidCoreAnimatorKey.contentsRect.rawValue, #keyPath(CALayer.contentsRect)),
+                        (FluidCoreAnimatorKey.cornerRadius.rawValue, #keyPath(CALayer.cornerRadius)),
+                        (FluidCoreAnimatorKey.filters.rawValue, #keyPath(CALayer.filters)),
+                        (FluidCoreAnimatorKey.frame.rawValue, #keyPath(CALayer.frame)),
+                        (FluidCoreAnimatorKey.hidden.rawValue, #keyPath(CALayer.isHidden)),
+                        (FluidCoreAnimatorKey.mask.rawValue, #keyPath(CALayer.mask)),
+                        (FluidCoreAnimatorKey.masksToBounds.rawValue, #keyPath(CALayer.masksToBounds)),
+                        (FluidCoreAnimatorKey.opacity.rawValue, #keyPath(CALayer.opacity)),
+                        (FluidCoreAnimatorKey.path.rawValue, #keyPath(CAShapeLayer.path)),
+                        (FluidCoreAnimatorKey.position.rawValue, #keyPath(CALayer.position)),
+                        (FluidCoreAnimatorKey.shadowColor.rawValue, #keyPath(CALayer.shadowColor)),
+                        (FluidCoreAnimatorKey.shadowOffset.rawValue, #keyPath(CALayer.shadowOffset)),
+                        (FluidCoreAnimatorKey.shadowOpacity.rawValue, #keyPath(CALayer.shadowOpacity)),
+                        (FluidCoreAnimatorKey.shadowPath.rawValue, #keyPath(CALayer.shadowPath)),
+                        (FluidCoreAnimatorKey.shadowRadius.rawValue, #keyPath(CALayer.shadowRadius)),
+                        (FluidCoreAnimatorKey.sublayers.rawValue, #keyPath(CALayer.sublayers)),
+                        (FluidCoreAnimatorKey.sublayerTransform.rawValue, #keyPath(CALayer.sublayerTransform)),
+                        (FluidCoreAnimatorKey.transform.rawValue, #keyPath(CALayer.transform)),
+                        (FluidCoreAnimatorKey.zPosition.rawValue, #keyPath(CALayer.zPosition)),
+                        (FluidCoreAnimatorKey.anchorPointX.rawValue, "\(#keyPath(CALayer.anchorPoint)).x"),
+                        (FluidCoreAnimatorKey.anchorPointy.rawValue, "\(#keyPath(CALayer.anchorPoint)).y"),
+                        (FluidCoreAnimatorKey.boundsOrigin.rawValue, "\(#keyPath(CALayer.bounds)).origin"),
+                        (FluidCoreAnimatorKey.boundsOriginX.rawValue, "\(#keyPath(CALayer.bounds)).origin.x"),
+                        (FluidCoreAnimatorKey.boundsOriginY.rawValue, "\(#keyPath(CALayer.bounds)).origin.y"),
+                        (FluidCoreAnimatorKey.boundsSize.rawValue, "\(#keyPath(CALayer.bounds)).size"),
+                        (FluidCoreAnimatorKey.boundsSizeWidth.rawValue, "\(#keyPath(CALayer.bounds)).size.width"),
+                        (FluidCoreAnimatorKey.boundsSizeHeight.rawValue, "\(#keyPath(CALayer.bounds)).size.height"),
+                        (FluidCoreAnimatorKey.contentsRectOrigin.rawValue, "\(#keyPath(CALayer.contentsRect)).origin"),
+                        (FluidCoreAnimatorKey.contentsRectOriginX.rawValue, "\(#keyPath(CALayer.contentsRect)).origin.x"),
+                        (FluidCoreAnimatorKey.contentsRectOriginY.rawValue, "\(#keyPath(CALayer.contentsRect)).origin.y"),
+                        (FluidCoreAnimatorKey.contentsRectSize.rawValue, "\(#keyPath(CALayer.contentsRect)).size"),
+                        (FluidCoreAnimatorKey.contentsRectSizeWidth.rawValue, "\(#keyPath(CALayer.contentsRect)).size.width"),
+                        (FluidCoreAnimatorKey.contentsRectSizeHeight.rawValue, "\(#keyPath(CALayer.contentsRect)).size.height"),
+                        (FluidCoreAnimatorKey.frameOrigin.rawValue, "\(#keyPath(CALayer.frame)).origin"),
+                        (FluidCoreAnimatorKey.frameOriginX.rawValue, "\(#keyPath(CALayer.frame)).origin.x"),
+                        (FluidCoreAnimatorKey.frameOriginY.rawValue, "\(#keyPath(CALayer.frame)).origin.y"),
+                        (FluidCoreAnimatorKey.frameSize.rawValue, "\(#keyPath(CALayer.frame)).size"),
+                        (FluidCoreAnimatorKey.frameSizeWidth.rawValue, "\(#keyPath(CALayer.frame)).size.width"),
+                        (FluidCoreAnimatorKey.frameSizeHeight.rawValue, "\(#keyPath(CALayer.frame)).size.height"),
+                        (FluidCoreAnimatorKey.positionX.rawValue, "\(#keyPath(CALayer.position)).x"),
+                        (FluidCoreAnimatorKey.positionY.rawValue, "\(#keyPath(CALayer.position)).y"),
+                        (FluidCoreAnimatorKey.shadowOffsetWidth.rawValue, "\(#keyPath(CALayer.shadowOffset)).width"),
+                        (FluidCoreAnimatorKey.shadowOffsetHeight.rawValue, "\(#keyPath(CALayer.shadowOffset)).height"),
+                        (FluidCoreAnimatorKey.sublayerTransformRotationX.rawValue, "\(#keyPath(CALayer.sublayerTransform)).rotation.x"),
+                        (FluidCoreAnimatorKey.sublayerTransformRotationY.rawValue, "\(#keyPath(CALayer.sublayerTransform)).rotation.y"),
+                        (FluidCoreAnimatorKey.sublayerTransformRotationZ.rawValue, "\(#keyPath(CALayer.sublayerTransform)).rotation.z"),
+                        (FluidCoreAnimatorKey.sublayerTransformScaleX.rawValue, "\(#keyPath(CALayer.sublayerTransform)).scale.x"),
+                        (FluidCoreAnimatorKey.sublayerTransformScaleY.rawValue, "\(#keyPath(CALayer.sublayerTransform)).scale.y"),
+                        (FluidCoreAnimatorKey.sublayerTransformScaleZ.rawValue, "\(#keyPath(CALayer.sublayerTransform)).scale.z"),
+                        (FluidCoreAnimatorKey.sublayerTransformTranslationX.rawValue, "\(#keyPath(CALayer.sublayerTransform)).translation.x"),
+                        (FluidCoreAnimatorKey.sublayerTransformTranslationY.rawValue, "\(#keyPath(CALayer.sublayerTransform)).translation.y"),
+                        (FluidCoreAnimatorKey.sublayerTransformTranslationZ.rawValue, "\(#keyPath(CALayer.sublayerTransform)).translation.z"),
+                        (FluidCoreAnimatorKey.transformRotationX.rawValue, "\(#keyPath(CALayer.transform)).rotation.x"),
+                        (FluidCoreAnimatorKey.transformRotationY.rawValue, "\(#keyPath(CALayer.transform)).rotation.y"),
+                        (FluidCoreAnimatorKey.transformRotationZ.rawValue, "\(#keyPath(CALayer.transform)).rotation.z"),
+                        (FluidCoreAnimatorKey.transformScaleX.rawValue, "\(#keyPath(CALayer.transform)).scale.x"),
+                        (FluidCoreAnimatorKey.transformScaleY.rawValue, "\(#keyPath(CALayer.transform)).scale.y"),
+                        (FluidCoreAnimatorKey.transformScaleZ.rawValue, "\(#keyPath(CALayer.transform)).scale.z"),
+                        (FluidCoreAnimatorKey.transformTranslationX.rawValue, "\(#keyPath(CALayer.transform)).translation.x"),
+                        (FluidCoreAnimatorKey.transformTranslationY.rawValue, "\(#keyPath(CALayer.transform)).translation.y"),
+                        (FluidCoreAnimatorKey.transformTranslationZ.rawValue, "\(#keyPath(CALayer.transform)).translation.z"),
+                    ]
+
+                    keyPaths.forEach { keyPath in
+                        expect(keyPath.actual).to(equal(keyPath.expected))
+                    }
+                }
+            }
+            describe("FluidCoreAnimatorValidator") {
+                it("validates layers, animation counts, completion state, and typed animation values") {
+                    FluidCoreAnimatorLogger.suppress = true
+                    defer { FluidCoreAnimatorLogger.suppress = false }
+
+                    let layer = CALayer()
+                    layer.bounds = CGRect(x: 2, y: 4, width: 30, height: 40)
+                    let targetBounds = CGRect(x: 10, y: 12, width: 50, height: 60)
+                    var validatedLayer: CALayer?
+
+                    expect {
+                        validatedLayer = try FluidCoreAnimatorValidator.validate(layer: layer, id: "valid-layer")
+                    }.notTo(throwError())
+                    expect(validatedLayer === layer).to(beTrue())
+                    expect(try? FluidCoreAnimatorValidator.validate(isCompleted: true,
+                                                                    state: .finished,
+                                                                    id: "complete")).to(beTrue())
+                    expect(try? FluidCoreAnimatorValidator.validate(count: 1, id: "has-animation")).to(beTrue())
+
+                    let validatedBounds = try? FluidCoreAnimatorValidator.validate(layer: layer,
+                                                                                   keyPath: FluidCoreAnimatorKey.bounds,
+                                                                                   from: nil,
+                                                                                   to: targetBounds,
+                                                                                   id: "bounds")
+                    expect(validatedBounds?.from).to(equal(layer.bounds))
+                    expect(validatedBounds?.to).to(equal(targetBounds))
+
+                    expect {
+                        try FluidCoreAnimatorValidator.validate(layer: nil, id: "nil-layer")
+                    }.to(throwError { error in
+                        guard case FluidCoreAnimatorError.layerIsNil(let id) = error else {
+                            fail("Expected layerIsNil error")
+                            return
+                        }
+                        expect(id).to(equal("nil-layer"))
+                    })
+                    expect {
+                        try FluidCoreAnimatorValidator.validate(isCompleted: false,
+                                                               state: .running,
+                                                               id: "running")
+                    }.to(throwError { error in
+                        guard case FluidCoreAnimatorError.alreadyCompleted(let id, let state) = error else {
+                            fail("Expected alreadyCompleted error")
+                            return
+                        }
+                        expect(id).to(equal("running"))
+                        expect(state).to(equal(.running))
+                    })
+                    expect {
+                        try FluidCoreAnimatorValidator.validate(count: 0, id: "empty")
+                    }.to(throwError { error in
+                        guard case FluidCoreAnimatorError.animationsIsEmpty(let id) = error else {
+                            fail("Expected animationsIsEmpty error")
+                            return
+                        }
+                        expect(id).to(equal("empty"))
+                    })
+                    expect {
+                        try FluidCoreAnimatorValidator.validate(layer: nil,
+                                                               keyPath: FluidCoreAnimatorKey.bounds,
+                                                               from: layer.bounds,
+                                                               to: targetBounds,
+                                                               id: "nil-generic-layer")
+                    }.to(throwError { error in
+                        guard case FluidCoreAnimatorError.layerIsNil(let id) = error else {
+                            fail("Expected layerIsNil error")
+                            return
+                        }
+                        expect(id).to(equal("nil-generic-layer"))
+                    })
+                    expect {
+                        try FluidCoreAnimatorValidator.validate(layer: layer,
+                                                               keyPath: FluidCoreAnimatorKey.bounds,
+                                                               from: layer.bounds,
+                                                               to: nil,
+                                                               id: "invalid-bounds")
+                    }.to(throwError { error in
+                        guard case FluidCoreAnimatorError.invalidArgument(let id, let key, _, _) = error else {
+                            fail("Expected invalidArgument error")
+                            return
+                        }
+                        expect(id).to(equal("invalid-bounds"))
+                        expect(key).to(equal(FluidCoreAnimatorKey.bounds.rawValue))
+                    })
+                }
+            }
             describe("FluidPropertyAnimator") {
                 it("runs, pauses, updates, resumes, stops, and invalidates queued animations") {
                     let view = UIView(frame: CGRect(x: 0, y: 0, width: 10, height: 10))

--- a/Tests/AnimatorSpec.swift
+++ b/Tests/AnimatorSpec.swift
@@ -549,6 +549,168 @@ final class AnimatorSpec: QuickSpec {
                     })
                 }
             }
+            describe("FluidCoreAnimator") {
+                it("creates configured spring, transition, and progress animations") {
+                    let layer = CALayer()
+                    let animator = FluidCoreAnimator(for: layer, id: "core-helper", duration: 2)!
+
+                    let springAnimation = animator.createAnimation(layer: layer,
+                                                                    keyPath: FluidCoreAnimatorKey.position,
+                                                                    from: CGPoint(x: 0, y: 0),
+                                                                    to: CGPoint(x: 12, y: 24),
+                                                                    duration: 1.25,
+                                                                    beginTime: 0.2,
+                                                                    timeOffset: 0.1,
+                                                                    easing: .spring(mass: 2,
+                                                                                    stiffness: 120,
+                                                                                    damping: 14,
+                                                                                    velocity: CGVector(dx: 3, dy: 4)),
+                                                                    isRemovedOnCompletion: false,
+                                                                    fillMode: .both,
+                                                                    repeatCount: 2,
+                                                                    repeatDuration: 3,
+                                                                    autoreverses: true) as? CASpringAnimation
+                    let transition = animator.createTransition(startProgress: 0.25,
+                                                               endProgress: 0.75,
+                                                               type: .push,
+                                                               subtype: .left,
+                                                               duration: 1.5,
+                                                               beginTime: 0.3,
+                                                               timeOffset: 0.2,
+                                                               easing: .easeOut,
+                                                               isRemovedOnCompletion: false,
+                                                               fillMode: .forwards,
+                                                               repeatCount: 3,
+                                                               repeatDuration: 4,
+                                                               autoreverses: true)
+                    let progress = animator.createProgressAnimation(duration: 1.75,
+                                                                    beginTime: 0.4,
+                                                                    timeOffset: 0.3,
+                                                                    easing: .easeIn,
+                                                                    isRemovedOnCompletion: false,
+                                                                    fillMode: .both,
+                                                                    repeatCount: 4,
+                                                                    repeatDuration: 5,
+                                                                    autoreverses: true)
+
+                    expect(springAnimation).notTo(beNil())
+                    expect(springAnimation?.keyPath).to(equal(FluidCoreAnimatorKey.position.rawValue))
+                    expect(springAnimation?.mass).to(beCloseTo(2))
+                    expect(springAnimation?.stiffness).to(beCloseTo(120))
+                    expect(springAnimation?.damping).to(beCloseTo(14))
+                    expect(springAnimation?.initialVelocity).to(beCloseTo(5))
+                    expect(springAnimation?.duration).to(beCloseTo(1.25))
+                    expect(springAnimation?.beginTime).to(beCloseTo(0.2))
+                    expect(springAnimation?.timeOffset).to(beCloseTo(0.1))
+                    expect(springAnimation?.isRemovedOnCompletion).to(beFalse())
+                    expect(springAnimation?.fillMode).to(equal(.both))
+                    expect(springAnimation?.repeatCount).to(beCloseTo(2))
+                    expect(springAnimation?.repeatDuration).to(beCloseTo(3))
+                    expect(springAnimation?.autoreverses).to(beTrue())
+
+                    expect(transition.startProgress).to(beCloseTo(0.25))
+                    expect(transition.endProgress).to(beCloseTo(0.75))
+                    expect(transition.type).to(equal(.push))
+                    expect(transition.subtype).to(equal(.fromLeft))
+                    expect(transition.duration).to(beCloseTo(1.5))
+                    expect(transition.beginTime).to(beCloseTo(0.3))
+                    expect(transition.timeOffset).to(beCloseTo(0.2))
+                    expect(transition.isRemovedOnCompletion).to(beFalse())
+                    expect(transition.fillMode).to(equal(.forwards))
+                    expect(transition.repeatCount).to(beCloseTo(3))
+                    expect(transition.repeatDuration).to(beCloseTo(4))
+                    expect(transition.autoreverses).to(beTrue())
+                    expect(transition.timingFunction).notTo(beNil())
+
+                    expect(progress.keyPath).to(equal("progress"))
+                    expect(progress.fromValue as? CGFloat).to(equal(0))
+                    expect(progress.toValue as? CGFloat).to(equal(1))
+                    expect(progress.duration).to(beCloseTo(1.75))
+                    expect(progress.beginTime).to(beCloseTo(0.4))
+                    expect(progress.timeOffset).to(beCloseTo(0.3))
+                    expect(progress.isRemovedOnCompletion).to(beFalse())
+                    expect(progress.fillMode).to(equal(.both))
+                    expect(progress.repeatCount).to(beCloseTo(4))
+                    expect(progress.repeatDuration).to(beCloseTo(5))
+                    expect(progress.autoreverses).to(beTrue())
+                }
+
+                it("runs, pauses, resumes, cancels, and invalidates animation groups") {
+                    let layer = CALayer()
+                    let animator = FluidCoreAnimator(for: layer, id: "core-lifecycle", duration: 1)!
+                    var progressValues = [CGFloat]()
+                    var stateValues = [FluidAnimatorState]()
+
+                    animator
+                        .on { progress in
+                            progressValues.append(progress)
+                        }
+                        .on { state, _ in
+                            stateValues.append(state)
+                        }
+                        .add(key: FluidCoreAnimatorKey.opacity, from: CGFloat(0), to: CGFloat(1))
+                        .add(startProgress: 0, endProgress: 1, type: .fade, subtype: nil)
+
+                    expect(animator.animationCount).to(equal(2))
+
+                    animator.run()
+                    animator.animationDidStart(animator.group)
+
+                    expect(layer.animation(forKey: animator.groupAnimationId)).notTo(beNil())
+                    expect(animator.progressLayer).notTo(beNil())
+                    expect(animator.animatorState).to(equal(.running))
+
+                    animator.progressDidChange(to: 0.4)
+                    expect(animator.animatorProgress).to(beCloseTo(0.4, within: 0.001))
+                    expect(progressValues).to(equal([0.4]))
+
+                    animator.pause()
+                    expect(animator.animatorState).to(equal(.paused))
+                    expect(layer.speed).to(beCloseTo(0))
+
+                    animator.update(progress: 0.5)
+                    expect(layer.timeOffset).to(beCloseTo(animator.startTime + 0.5, within: 0.001))
+
+                    animator.resume(reverse: false, progress: nil)
+                    expect(animator.animatorState).to(equal(.running))
+                    expect(layer.speed).to(beCloseTo(1))
+                    expect(layer.timeOffset).to(beCloseTo(0))
+
+                    animator.pause()
+                    animator.resume(reverse: true, progress: 0.25, resetSpeedAfterFinish: false)
+                    expect(animator.animatorState).to(equal(.running))
+                    expect(layer.speed).to(beCloseTo(-1))
+
+                    animator.cancel()
+                    expect(animator.animatorState).to(equal(.cancelled))
+                    expect(layer.animation(forKey: animator.groupAnimationId)).to(beNil())
+
+                    animator.invalidate()
+                    expect(animator.layer).to(beNil())
+                    expect(animator.group).to(beNil())
+                    expect(animator.animations).to(beNil())
+                    expect(animator.progressLayer).to(beNil())
+                    expect(animator.progressAnimation).to(beNil())
+                    expect(stateValues).to(contain(.running, .paused, .cancelled))
+                }
+
+                it("snaps near-edge progress when core animations stop") {
+                    let animator = FluidCoreAnimator(for: CALayer(), id: "core-stop", duration: 1)!
+
+                    animator._animatorProgress = 0.01
+                    animator.animationDidStop(CAAnimation(), finished: true)
+
+                    expect(animator.animatorProgress).to(equal(0))
+                    expect(animator.animatorState).to(equal(.finished))
+
+                    animator._animatorState = .running
+                    animator._animatorProgress = 0.99
+                    animator.animationDidStop(CAAnimation(), finished: true)
+
+                    expect(animator.animatorProgress).to(equal(1))
+                    expect(animator.animatorState).to(equal(.finished))
+                }
+            }
             describe("FluidPropertyAnimator") {
                 it("runs, pauses, updates, resumes, stops, and invalidates queued animations") {
                     let view = UIView(frame: CGRect(x: 0, y: 0, width: 10, height: 10))

--- a/Tests/EnumSpec.swift
+++ b/Tests/EnumSpec.swift
@@ -9,11 +9,97 @@
 import Quick
 import Nimble
 import UIKit
+import Darwin
 @testable import Fluidable
 
 final class EnumSpec: QuickSpec {
     override class func spec() {
+        func captureStandardOutput(_ body: () -> Void) -> String {
+            let pipe = Pipe()
+            let originalStandardOutput = dup(STDOUT_FILENO)
+
+            fflush(stdout)
+            dup2(pipe.fileHandleForWriting.fileDescriptor, STDOUT_FILENO)
+            body()
+            fflush(stdout)
+            dup2(originalStandardOutput, STDOUT_FILENO)
+            close(originalStandardOutput)
+
+            pipe.fileHandleForWriting.closeFile()
+            let data = pipe.fileHandleForReading.readDataToEndOfFile()
+            return String(data: data, encoding: .utf8) ?? ""
+        }
+
         describe("Enumeration") {
+            describe("FluidError") {
+                let invalidReference: FluidError = .invalidReference
+                let unsupportedPresentationEasing: FluidError = .unsupportedPresentationEasing(easing: .easeInBack)
+                let unsupportedDismissalEasing: FluidError = .unsupportedDismissalEasing(easing: .easeOutBack)
+                let ignoredPresentationDuration: FluidError = .ignoredPresentationDuration(easing: .spring, defaultDuration: 0.4, userDefinedDuration: 1.2)
+                let ignoredDismissalDuration: FluidError = .ignoredDismissalDuration(easing: .spring, defaultDuration: 0.5, userDefinedDuration: 1.3)
+                let invalidInitialFrameDimension: FluidError = .invalidInitialFrameDimension
+                let invalidFinalFrameDimension: FluidError = .invalidFinalFrameDimension
+                let invalidResizeConfiguration: FluidError = .invalidResizeConfiguration
+
+                it("Description") {
+                    expect(String(describing: FluidErrorLevel.error)).to(equal("error"))
+                    expect(String(describing: FluidErrorLevel.warn)).to(equal("warn"))
+                    expect(String(describing: FluidErrorLevel.info)).to(equal("info"))
+
+                    expect(String(describing: invalidReference.level)).to(equal("error"))
+                    expect(String(describing: unsupportedPresentationEasing.level)).to(equal("error"))
+                    expect(String(describing: unsupportedDismissalEasing.level)).to(equal("error"))
+                    expect(String(describing: ignoredPresentationDuration.level)).to(equal("warn"))
+                    expect(String(describing: ignoredDismissalDuration.level)).to(equal("warn"))
+                    expect(String(describing: invalidInitialFrameDimension.level)).to(equal("warn"))
+                    expect(String(describing: invalidFinalFrameDimension.level)).to(equal("warn"))
+                    expect(String(describing: invalidResizeConfiguration.level)).to(equal("error"))
+
+                    expect(invalidReference.description).to(contain("already disposed"))
+                    expect(unsupportedPresentationEasing.description).to(contain("easeInBack"))
+                    expect(unsupportedDismissalEasing.description).to(contain("easeOutBack"))
+                    expect(ignoredPresentationDuration.description).to(contain("present duration (1.2)"))
+                    expect(ignoredPresentationDuration.description).to(contain("default duration (0.4)"))
+                    expect(ignoredDismissalDuration.description).to(contain("dismiss duration (1.3)"))
+                    expect(ignoredDismissalDuration.description).to(contain("default duration (0.5)"))
+                    expect(invalidInitialFrameDimension.description).to(contain("will be ignored"))
+                    expect(invalidFinalFrameDimension.description).to(contain("needs to set"))
+                    expect(invalidResizeConfiguration.description).to(contain("bottom drawer"))
+                }
+
+                it("PrintMessage") {
+                    let output = captureStandardOutput {
+                        invalidReference.printMessage()
+                        unsupportedPresentationEasing.printMessage()
+                        unsupportedDismissalEasing.printMessage()
+                        ignoredPresentationDuration.printMessage()
+                        ignoredDismissalDuration.printMessage()
+                        invalidInitialFrameDimension.printMessage()
+                        invalidFinalFrameDimension.printMessage()
+                        invalidResizeConfiguration.printMessage()
+                    }
+
+                    expect(output).to(contain("The transition is cancelled"))
+                    expect(output).to(contain("Available easing types for iOS 10"))
+                    expect(output).to(contain("present duration (1.2)"))
+                    expect(output).to(contain("dismiss duration (1.3)"))
+                    expect(output).to(contain("will be ignored"))
+                    expect(output).to(contain("needs to set"))
+                    expect(output).to(contain("bottom drawer"))
+                }
+            }
+            describe("FluidCoreAnimatorError") {
+                it("Description") {
+                    expect(FluidCoreAnimatorError.layerIsNil(id: "layer").description).to(contain("[layer]"))
+                    expect(FluidCoreAnimatorError.layerIsNil(id: "layer").description).to(contain("already invalidated"))
+                    expect(FluidCoreAnimatorError.animationsIsEmpty(id: "animation").description).to(contain("[animation]"))
+                    expect(FluidCoreAnimatorError.animationsIsEmpty(id: "animation").description).to(contain("could not be created"))
+                    expect(FluidCoreAnimatorError.alreadyCompleted(id: "completed", state: .finished).description).to(contain("[completed]"))
+                    expect(FluidCoreAnimatorError.alreadyCompleted(id: "completed", state: .finished).description).to(contain("finished"))
+                    expect(FluidCoreAnimatorError.invalidArgument(id: "argument", key: "opacity", from: nil, to: 1.0).description).to(contain("[argument]"))
+                    expect(FluidCoreAnimatorError.invalidArgument(id: "argument", key: "opacity", from: nil, to: 1.0).description).to(contain("opacity"))
+                }
+            }
             describe("FluidAnimationType") {
                 let present: FluidAnimationType = FluidAnimationType.present
                 let dismiss: FluidAnimationType = FluidAnimationType.dismiss

--- a/Tests/QuartzCoreSpec.swift
+++ b/Tests/QuartzCoreSpec.swift
@@ -71,6 +71,61 @@ final class QuartzCoreSpec: QuickSpec {
                     expect(layer.sublayer(with: "sublayer0")).to(beNil())
                 }
             }
+            describe("CAProgressLayer") {
+                it("initializes, copies, and encodes progress") {
+                    let defaultLayer = CAProgressLayer()
+                    expect(defaultLayer.frame).to(equal(.zero))
+                    expect(defaultLayer.progress).to(equal(0))
+
+                    let layer = CAProgressLayer(frame: CGRect(x: 1, y: 2, width: 30, height: 40))
+                    expect(layer.frame).to(equal(CGRect(x: 1, y: 2, width: 30, height: 40)))
+                    expect(layer.progress).to(equal(0))
+
+                    layer.preferredInvocationFramePerSeconds = 120
+                    expect(layer.preferredInvocationFramePerSeconds).to(equal(120))
+
+                    layer.progress = 0.35
+                    let copiedLayer = CAProgressLayer(layer: layer)
+                    expect(copiedLayer.progress).to(equal(0.35))
+
+                    let layerCopiedFromCALayer = CAProgressLayer(layer: CALayer())
+                    expect(layerCopiedFromCALayer.progress).to(equal(0))
+
+                    let archiver = NSKeyedArchiver(requiringSecureCoding: false)
+                    layer.encode(with: archiver)
+                    archiver.finishEncoding()
+
+                    let unarchiver = try! NSKeyedUnarchiver(forReadingFrom: archiver.encodedData)
+                    let decodedLayer = CAProgressLayer(coder: unarchiver)
+                    unarchiver.finishDecoding()
+                    expect(decodedLayer?.progress).to(beCloseTo(0.35, within: 0.000001))
+                }
+
+                it("marks progress changes as displayable") {
+                    expect(CAProgressLayer.needsDisplay(forKey: "progress")).to(beTrue())
+                    expect(CAProgressLayer.needsDisplay(forKey: "bounds")).to(beFalse())
+                }
+
+                it("keeps progress unchanged when displayed without a presentation layer") {
+                    let layer = CAProgressLayer()
+                    layer.progress = 0.5
+
+                    layer.display()
+
+                    expect(layer.progress).to(equal(0.5))
+                }
+
+                it("backs UIProgressLayerView progress with its layer") {
+                    let view = UIProgressLayerView(frame: CGRect(x: 0, y: 0, width: 12, height: 24))
+                    expect(view.layer).to(beAnInstanceOf(CAProgressLayer.self))
+                    expect(view.layer.frame.size).to(equal(CGSize(width: 12, height: 24)))
+
+                    view.progress = 0.75
+                    expect(view.layer.progress).to(equal(0.75))
+                    view.layer.progress = 0.25
+                    expect(view.progress).to(equal(0.25))
+                }
+            }
             describe("CATransform3D") {
                 it("Initialization") {
                     let trans0: CATransform3D = CATransform3D(with: CGAffineTransform(tx: 2, ty: 2))

--- a/Tests/UIKitSpec.swift
+++ b/Tests/UIKitSpec.swift
@@ -470,6 +470,123 @@ final class UIKitSpec: QuickSpec {
                     expect(shadowView.layer.shadowPath).notTo(beNil())
                     expect((shadowView.layer.mask as? CAShapeLayer)?.path).notTo(beNil())
                 }
+
+                it("configures transition and interruptible animator state") {
+                    let fixture = makeCoreTestTransitionFixture(style: .slide(direction: .fromBottom))
+                    let animator = fixture.presentAnimator
+                    let layoutContainerView = animator.layoutContainerView!
+                    let backgroundView = FluidDimmedBackgroundView(color: .black)
+                    let shadowView = FluidShadowView(shadowCornerRadius: 0,
+                                                     shadowRoundingCorners: nil,
+                                                     shadowOpacity: 0,
+                                                     shadowColor: UIColor.black.cgColor,
+                                                     shadowRadius: 0,
+                                                     shadowOffset: .zero,
+                                                     isTransparentBackground: false)
+                    var progressValues = [CGFloat]()
+                    var stateValues = [String]()
+                    var completionWasStored = false
+
+                    fixture.container.insertSubview(backgroundView, belowSubview: layoutContainerView)
+                    fixture.container.addSubview(shadowView)
+                    var parameters = animator.parameters!
+                    parameters.layoutContainerView = layoutContainerView
+                    parameters.backgroundView = backgroundView
+                    parameters.shadowView = shadowView
+                    parameters.shouldCastShadow = true
+                    parameters.shouldMaskCorner = true
+                    parameters.initialStyle = FluidInitialFrameStyle(alpha: 1,
+                                                                     cornerRadius: 6,
+                                                                     shadowColor: UIColor.blue.cgColor,
+                                                                     shadowOpacity: 0.25,
+                                                                     shadowRadius: 3,
+                                                                     shadowOffset: CGSize(width: -1, height: 2))
+                    parameters.finalStyle = FluidFinalFrameStyle(alpha: 1,
+                                                                 cornerRadius: 18,
+                                                                 cornerStyle: .top,
+                                                                 shadowColor: UIColor.red.cgColor,
+                                                                 shadowOpacity: 0.75,
+                                                                 shadowRadius: 9,
+                                                                 shadowOffset: CGSize(width: 3, height: 4))
+                    animator.parameters = parameters
+
+                    animator.configureTransitionAnimators(isReversed: false,
+                                                          from: 0,
+                                                          to: 1,
+                                                          progress: { progressValues.append($0) },
+                                                          state: { state, progress in
+                                                              stateValues.append("\(state):\(progress)")
+                                                          })
+                    animator.configureInterruptibleAnimator { _, _ in
+                        completionWasStored = true
+                    }
+
+                    expect(animator.framePropertyAnimators?.count).to(equal(2))
+                    expect(animator.frameCoreAnimators?.count).to(equal(1))
+                    expect(animator.backgroundAnimator).notTo(beNil())
+                    expect(animator.progressView).to(beIdenticalTo(fixture.container.viewWithTag(FluidConst.progressViewTag)))
+                    expect(animator.progressAnimator).notTo(beNil())
+                    expect(animator.interruptibleView).to(beIdenticalTo(fixture.container.viewWithTag(FluidConst.interruptibleViewTag)))
+                    expect(animator.interruptibleView?.alpha).to(beCloseTo(0))
+                    expect(animator.interruptibleAnimator?.completionBlock).notTo(beNil())
+                    expect(completionWasStored).to(beFalse())
+
+                    animator.progressAnimatorDidUpdate(progress: 0.42)
+                    animator.progressAnimatorStateDidChange(state: .finished, progress: 1)
+
+                    expect(progressValues).to(equal([0.42]))
+                    expect(stateValues).to(equal(["finished:1.0"]))
+                }
+
+                it("creates shadow and corner animators from configured styles") {
+                    let fixture = makeCoreTestTransitionFixture(style: .slide(direction: .fromBottom))
+                    let animator = fixture.presentAnimator
+                    let layoutContainerView = animator.layoutContainerView!
+                    let shadowView = FluidShadowView(shadowCornerRadius: 0,
+                                                     shadowRoundingCorners: nil,
+                                                     shadowOpacity: 0,
+                                                     shadowColor: UIColor.black.cgColor,
+                                                     shadowRadius: 0,
+                                                     shadowOffset: .zero,
+                                                     isTransparentBackground: false)
+
+                    fixture.container.addSubview(shadowView)
+                    var parameters = animator.parameters!
+                    parameters.layoutContainerView = layoutContainerView
+                    parameters.shadowView = shadowView
+                    parameters.shouldCastShadow = true
+                    parameters.shouldMaskCorner = true
+                    parameters.initialStyle = FluidInitialFrameStyle(alpha: 1,
+                                                                     cornerRadius: 4,
+                                                                     shadowColor: UIColor.blue.cgColor,
+                                                                     shadowOpacity: 0.2,
+                                                                     shadowRadius: 2,
+                                                                     shadowOffset: CGSize(width: -2, height: 1))
+                    parameters.finalStyle = FluidFinalFrameStyle(alpha: 1,
+                                                                 cornerRadius: 16,
+                                                                 cornerStyle: .bottom,
+                                                                 shadowColor: UIColor.red.cgColor,
+                                                                 shadowOpacity: 0.6,
+                                                                 shadowRadius: 8,
+                                                                 shadowOffset: CGSize(width: 3, height: 5))
+                    animator.parameters = parameters
+
+                    let expectedShadowFrame = animator.toShadowFrame(false, 0)
+                    let shadowAnimators = animator.createShadowPropertyAnimation(false)
+                    let cornerAnimators = animator.createCornerRadiusPropertyAnimation(false)
+
+                    expect(shadowAnimators.count).to(equal(1))
+                    expect(cornerAnimators.count).to(equal(1))
+                    expect(shadowView.layer.frame).to(equal(expectedShadowFrame))
+                    expect(shadowView.layer.cornerRadius).to(beCloseTo(16))
+                    expect(CGFloat(shadowView.layer.shadowOpacity)).to(beCloseTo(0.6, within: 0.001))
+                    expect(shadowView.layer.shadowRadius).to(beCloseTo(8))
+                    expect(shadowView.layer.shadowOffset).to(equal(CGSize(width: 3, height: 5)))
+                    expect(shadowView.layer.shadowPath).notTo(beNil())
+                    expect(animator.layoutContainerView.layer.masksToBounds).to(beTrue())
+                    expect(animator.layoutContainerView.layer.cornerRadius).to(beCloseTo(4))
+                    expect(animator.layoutContainerView.layer.maskedCorners).to(equal(animator.initialStyle.maskedCorners))
+                }
             }
             describe("FluidShadowLayer") {
                 it("creates expanded shadow frames and optional masks") {

--- a/Tests/UIKitSpec.swift
+++ b/Tests/UIKitSpec.swift
@@ -587,6 +587,42 @@ final class UIKitSpec: QuickSpec {
                     expect(fromLeft.presentDriver.calculateInteractionProgress()).to(beCloseTo(0.6, within: 0.001))
                 }
 
+                it("drives present pan gesture interaction paths") {
+                    let fixture = makeCoreTestTransitionFixture(style: .slide(direction: .fromRight))
+                    let gesture = StubPanGestureRecognizer()
+                    let observer = fixture.presentDriver.observingGesture!
+
+                    fixture.presentDriver.interruptibleAnimator = UIViewPropertyAnimator(duration: 1, curve: .linear)
+                    observer.baseFrame = fixture.destinationViewController.view.frame
+                    observer.panGestureView = fixture.destinationViewController.view
+                    observer.currentLocation = CGPoint(x: 220, y: 0)
+                    observer.currentTranslation = CGPoint(x: -40, y: 0)
+                    observer.currentVelocity = CGVector(dx: -2_000, dy: 0)
+                    observer.translationHistory = [CGPoint(x: -40, y: 0), .zero]
+
+                    fixture.presentDriver.beginPanGesture(gesture: gesture, isEdgePan: false)
+
+                    expect(fixture.presentDriver.isInteracting).to(beTrue())
+                    expect(fixture.presentDriver.pausedInterruptibleFractionComplete).to(beCloseTo(0))
+                    expect(fixture.sourceDelegate.presentInteractionStates.map { String(describing: $0) }).to(equal(["begin"]))
+
+                    observer.currentLocation = CGPoint(x: 80, y: 0)
+                    observer.currentTranslation = CGPoint(x: -140, y: 0)
+                    observer.translationHistory = [CGPoint(x: -140, y: 0), .zero]
+                    fixture.presentDriver.updatePanGesture(gesture: gesture, isEdgePan: false)
+
+                    expect(fixture.presentAnimator.interactionProgress).to(beCloseTo(0.4375, within: 0.001))
+                    expect(fixture.sourceDelegate.presentInteractionStates.map { String(describing: $0) }).to(equal(["begin", "update"]))
+
+                    fixture.presentDriver.finishPanGesture(gesture: gesture, isEdgePan: false)
+
+                    expect(fixture.presentDriver.isInteracting).to(beFalse())
+                    expect(fixture.presentDriver.isInteractionCancelled).to(beFalse())
+                    expect(fixture.sourceDelegate.presentInteractionStates.map { String(describing: $0) }).to(equal(["begin", "update", "end"]))
+                    expect(fixture.destinationDelegate.presentInteractionStates.map { String(describing: $0) }).to(equal(["begin", "update", "end"]))
+                    expect(fixture.presentDriver.observingGesture).to(beNil())
+                }
+
                 it("evaluates dismiss interaction progress and finish conditions") {
                     let fixture = makeCoreTestTransitionFixture(style: .slide(direction: .fromRight))
                     seedGesture(fixture.dismissDriver.observingGesture,
@@ -616,6 +652,67 @@ final class UIKitSpec: QuickSpec {
                                 averageVector: CGPoint(x: 30, y: 0),
                                 velocity: CGVector(dx: 2_000, dy: 0))
                     expect(blockedFixture.dismissDriver.canBeginDismissInteraction(isEdgePan: false)).to(beFalse())
+                }
+
+                it("drives dismiss pan gesture interaction paths") {
+                    let fixture = makeCoreTestTransitionFixture(style: .slide(direction: .fromRight))
+                    let gesture = StubPanGestureRecognizer()
+                    let observer = fixture.dismissDriver.observingGesture!
+
+                    observer.baseFrame = fixture.destinationViewController.view.frame
+                    observer.panGestureView = fixture.destinationViewController.view
+                    observer.currentLocation = CGPoint(x: 20, y: 0)
+                    observer.currentTranslation = CGPoint(x: 40, y: 0)
+                    observer.currentVelocity = CGVector(dx: 2_000, dy: 0)
+                    observer.translationHistory = [CGPoint(x: 40, y: 0), .zero]
+
+                    fixture.dismissDriver.beginPanGesture(gesture: gesture, isEdgePan: false)
+
+                    expect(fixture.dismissDriver.isInteracting).to(beTrue())
+                    expect(fixture.sourceDelegate.dismissInteractionStates.map { String(describing: $0) }).to(equal(["begin"]))
+
+                    observer.currentLocation = CGPoint(x: 180, y: 0)
+                    observer.currentTranslation = CGPoint(x: 160, y: 0)
+                    observer.translationHistory = [CGPoint(x: 160, y: 0), .zero]
+                    fixture.dismissDriver.updatePanGesture(gesture: gesture, isEdgePan: false)
+
+                    expect(fixture.dismissDriver.interactionState).to(equal(.dismissing))
+                    expect(fixture.dismissAnimator.interactionProgress).to(beCloseTo(0.5, within: 0.001))
+                    expect(fixture.sourceDelegate.dismissInteractionStates.map { String(describing: $0) }).to(equal(["begin", "update"]))
+
+                    observer.currentLocation = CGPoint(x: 260, y: 0)
+                    observer.currentTranslation = CGPoint(x: 240, y: 0)
+                    observer.translationHistory = [CGPoint(x: 240, y: 0), .zero]
+                    fixture.dismissDriver.finishPanGesture(gesture: gesture, isEdgePan: false)
+
+                    expect(fixture.dismissDriver.isInteracting).to(beFalse())
+                    expect(fixture.dismissDriver.isInteractionCancelled).to(beFalse())
+                    expect(fixture.sourceDelegate.dismissInteractionStates.map { String(describing: $0) }).to(equal(["begin", "update", "end"]))
+                    expect(fixture.destinationDelegate.dismissInteractionStates.map { String(describing: $0) }).to(equal(["begin", "update", "end"]))
+                }
+
+                it("begins dismiss interaction from a valid edge pan") {
+                    let fixture = makeCoreTestTransitionFixture(style: .slide(direction: .fromRight))
+                    let gesture = StubScreenEdgePanGestureRecognizer()
+                    let observer = fixture.dismissDriver.observingGesture!
+
+                    observer.baseFrame = fixture.destinationViewController.view.frame
+                    observer.panGestureView = fixture.destinationViewController.view
+                    observer.currentLocation = CGPoint(x: 0, y: 0)
+                    observer.currentTranslation = CGPoint(x: 24, y: 0)
+                    observer.currentVelocity = .zero
+                    observer.translationHistory = [CGPoint(x: 24, y: 0), .zero]
+
+                    fixture.dismissDriver.beginPanGesture(gesture: gesture, isEdgePan: true)
+
+                    expect(fixture.dismissDriver.isInteracting).to(beTrue())
+                    expect(fixture.dismissDriver.currentInteractionProgress).to(beCloseTo(0))
+
+                    observer.currentLocation = CGPoint(x: 128, y: 0)
+                    observer.currentTranslation = CGPoint(x: 128, y: 0)
+                    observer.translationHistory = [CGPoint(x: 128, y: 0), .zero]
+
+                    expect(fixture.dismissDriver.calculateTransitionProgress(isEdgePan: true)).to(beCloseTo(0.4, within: 0.001))
                 }
 
                 it("propagates dismiss interaction lifecycle and starts completion paths") {

--- a/Tests/UIKitSpec.swift
+++ b/Tests/UIKitSpec.swift
@@ -946,6 +946,23 @@ final class UIKitSpec: QuickSpec {
                                                     animatorDelay: 0.5)).to(beCloseTo(1))
                 }
 
+                it("uses active duration and zero delay when converting progress without overrides") {
+                    let fixture = makeCoreTestTransitionFixture()
+                    let animator = fixture.presentAnimator
+                    var parameters = animator.parameters!
+                    parameters.activeDuration = 2
+                    animator.parameters = parameters
+
+                    expect(animator.convertProgress(transitionProgress: 0.25,
+                                                    transitionDuration: 4,
+                                                    animatorDuration: nil,
+                                                    animatorDelay: nil)).to(beCloseTo(0.5, within: 0.001))
+                    expect(animator.convertProgress(transitionProgress: 0.75,
+                                                    transitionDuration: 4,
+                                                    animatorDuration: nil,
+                                                    animatorDelay: nil)).to(beCloseTo(1))
+                }
+
                 it("pauses, updates, and finishes core animation groups") {
                     let fixture = makeCoreTestTransitionFixture()
                     let animator = fixture.presentAnimator

--- a/Tests/UIKitSpec.swift
+++ b/Tests/UIKitSpec.swift
@@ -25,6 +25,33 @@ final class UIKitSpec: QuickSpec {
 
     class TestInteractiveView: UIView, FluidInteractiveView {}
 
+    class TestBlurredBackgroundView: FluidBlurredBackgroundView {
+        var blurRadiusValues: [CGFloat] = []
+        var colorTintValues: [UIColor?] = []
+        var colorTintAlphaValues: [CGFloat] = []
+        var scaleValues: [CGFloat] = []
+
+        override var blurRadius: CGFloat {
+            get { return blurRadiusValues.last ?? 0 }
+            set { blurRadiusValues.append(newValue) }
+        }
+
+        override var colorTint: UIColor? {
+            get { return colorTintValues.last ?? nil }
+            set { colorTintValues.append(newValue) }
+        }
+
+        override var colorTintAlpha: CGFloat {
+            get { return colorTintAlphaValues.last ?? 0 }
+            set { colorTintAlphaValues.append(newValue) }
+        }
+
+        override var scale: CGFloat {
+            get { return scaleValues.last ?? 0 }
+            set { scaleValues.append(newValue) }
+        }
+    }
+
     class TestNavigationController: UINavigationController {
         var name: String?
         init(rootViewController: UIViewController, name: String) {
@@ -525,6 +552,62 @@ final class UIKitSpec: QuickSpec {
                                                     animatorDelay: 0.5)).to(beCloseTo(1))
                 }
 
+                it("pauses, updates, and finishes core animation groups") {
+                    let fixture = makeCoreTestTransitionFixture()
+                    let animator = fixture.presentAnimator
+                    let info = FluidGestureInfo(direction: .leftMiddle)
+                    let progressView = UIView(frame: fixture.container.bounds)
+                    let frameView = UIView(frame: fixture.container.bounds)
+                    let extraView = UIView(frame: fixture.container.bounds)
+                    let progressAnimator = FluidCoreAnimator(for: progressView,
+                                                             id: "test.progress",
+                                                             duration: 2)!
+                    let frameAnimator = FluidCoreAnimator(for: frameView,
+                                                          id: "test.frame",
+                                                          duration: 1,
+                                                          beginTime: 0.5)!
+                    let extraAnimator = FluidCoreAnimator(for: extraView,
+                                                          id: "test.extra",
+                                                          duration: 2,
+                                                          beginTime: 0.25)!
+
+                    fixture.container.addSubview(progressView)
+                    fixture.container.addSubview(frameView)
+                    fixture.container.addSubview(extraView)
+                    progressAnimator._animatorState = .running
+                    frameAnimator._animatorState = .running
+                    extraAnimator._animatorState = .running
+
+                    var parameters = animator.parameters!
+                    parameters.activeDuration = 2
+                    parameters.progressAnimator = progressAnimator
+                    parameters.frameCoreAnimators = [frameAnimator]
+                    parameters.extraCoreAnimators = [extraAnimator]
+                    animator.parameters = parameters
+
+                    animator.pauseAnimation(progress: 0.25, position: 0.1, info: info)
+
+                    expect(animator.pausedAnimationProgress).to(beCloseTo(0.25))
+                    expect(String(describing: progressAnimator.animatorState)).to(equal("paused"))
+                    expect(String(describing: frameAnimator.animatorState)).to(equal("paused"))
+                    expect(String(describing: extraAnimator.animatorState)).to(equal("paused"))
+
+                    animator.updateAnimation(progress: 0.75, position: 0.4, info: info)
+
+                    expect(frameAnimator.layer?.timeOffset).to(beCloseTo(1, within: 0.001))
+                    expect(extraAnimator.layer?.timeOffset).to(beCloseTo(1.25, within: 0.001))
+                    expect(progressAnimator.layer?.timeOffset).to(beCloseTo(1.5, within: 0.001))
+
+                    animator.finishAnimation(isReversed: false, progress: 0.75, position: 0.6, info: info)
+
+                    expect(String(describing: progressAnimator.animatorState)).to(equal("running"))
+                    expect(String(describing: frameAnimator.animatorState)).to(equal("running"))
+                    expect(String(describing: extraAnimator.animatorState)).to(equal("running"))
+                    expect(frameAnimator.layer?.speed).to(beCloseTo(1))
+                    expect(extraAnimator.layer?.speed).to(beCloseTo(1))
+                    expect(progressAnimator.layer?.speed).to(beCloseTo(1))
+                }
+
                 it("applies shadow layer properties and transparent masks") {
                     let fixture = makeCoreTestTransitionFixture()
                     let shadowView = FluidShadowView(shadowCornerRadius: 0,
@@ -867,6 +950,68 @@ final class UIKitSpec: QuickSpec {
                     expect(decoded?.shadowCornerRadius).to(beCloseTo(layer.shadowCornerRadius))
                     expect(decoded?.isTransparentBackground).to(equal(layer.isTransparentBackground))
                     expect(FluidShadowLayer.needsDisplay(forKey: "shadowOpacity")).to(beFalse())
+                }
+            }
+            describe("FluidBackgroundView") {
+                it("fits dimmed backgrounds and clamps visibility") {
+                    let container = UIView(frame: CGRect(x: 0, y: 0, width: 200, height: 120))
+                    let backgroundView = FluidDimmedBackgroundView(color: .red)
+
+                    container.addSubview(backgroundView)
+
+                    expect(backgroundView.backgroundColor).to(equal(.red))
+                    expect(backgroundView.alpha).to(beCloseTo(0))
+                    expect(backgroundView.isUserInteractionEnabled).to(beFalse())
+                    expect(backgroundView.tag).to(equal(FluidConst.backgroundViewTag))
+
+                    backgroundView.visibility = 0.5
+                    expect(backgroundView.alpha).to(beCloseTo(0.5))
+                    backgroundView.visibility = -1
+                    expect(backgroundView.alpha).to(beCloseTo(0))
+                    backgroundView.visibility = 2
+                    expect(backgroundView.alpha).to(beCloseTo(1))
+
+                    backgroundView.updateConstraints()
+
+                    let attachedConstraints = container.constraints.filter { constraint in
+                        return (constraint.firstItem as? UIView) === backgroundView ||
+                               (constraint.secondItem as? UIView) === backgroundView
+                    }
+                    expect(backgroundView.translatesAutoresizingMaskIntoConstraints).to(beFalse())
+                    expect(attachedConstraints.count).to(equal(4))
+                }
+
+                it("fits blurred backgrounds and maps visibility to blur radius") {
+                    let container = UIView(frame: CGRect(x: 0, y: 0, width: 200, height: 120))
+                    let backgroundView = TestBlurredBackgroundView(radius: 20, color: .blue, alpha: 0.35)
+
+                    container.addSubview(backgroundView)
+
+                    expect(backgroundView.baseBlurRadius).to(beCloseTo(20))
+                    expect(backgroundView.blurRadius).to(beCloseTo(0))
+                    expect(backgroundView.colorTint).to(equal(.blue))
+                    expect(backgroundView.colorTintAlpha).to(beCloseTo(0.35, within: 0.001))
+                    expect(backgroundView.isUserInteractionEnabled).to(beFalse())
+                    expect(backgroundView.tag).to(equal(FluidConst.backgroundViewTag))
+
+                    backgroundView.visibility = 0.25
+                    expect(backgroundView.blurRadius).to(beCloseTo(5))
+                    backgroundView.visibility = -1
+                    expect(backgroundView.blurRadius).to(beCloseTo(0))
+                    backgroundView.visibility = 2
+                    expect(backgroundView.blurRadius).to(beCloseTo(20))
+
+                    backgroundView.scale = 2
+                    expect(backgroundView.scale).to(beCloseTo(2))
+
+                    backgroundView.updateConstraints()
+
+                    let attachedConstraints = container.constraints.filter { constraint in
+                        return (constraint.firstItem as? UIView) === backgroundView ||
+                               (constraint.secondItem as? UIView) === backgroundView
+                    }
+                    expect(backgroundView.translatesAutoresizingMaskIntoConstraints).to(beFalse())
+                    expect(attachedConstraints.count).to(equal(4))
                 }
             }
             describe("FluidInteractiveView") {

--- a/Tests/UIKitSpec.swift
+++ b/Tests/UIKitSpec.swift
@@ -528,6 +528,88 @@ final class UIKitSpec: QuickSpec {
                                 velocity: CGVector(dx: 2_000, dy: 0))
                     expect(blockedFixture.dismissDriver.canBeginDismissInteraction(isEdgePan: false)).to(beFalse())
                 }
+
+                it("propagates dismiss interaction lifecycle and starts completion paths") {
+                    let cancelledFixture = makeCoreTestTransitionFixture(style: .slide(direction: .fromRight))
+                    let info = FluidGestureInfo(locationLocal: CGPoint(x: 24, y: 32),
+                                                locationGlobal: CGPoint(x: 24, y: 32),
+                                                translation: CGPoint(x: 80, y: 0),
+                                                velocity: CGVector(dx: 2_000, dy: 0),
+                                                direction: .rightMiddle)
+                    cancelledFixture.dismissDriver.currentInteractionProgress = 0.25
+                    cancelledFixture.dismissDriver.currentResizePosition = 0
+
+                    cancelledFixture.dismissDriver.beginInteractiveTransition(progress: 0.25, position: 0, info: info)
+
+                    expect(cancelledFixture.dismissAnimator.interactionProgress).to(beCloseTo(0.25))
+                    expect(cancelledFixture.dismissAnimator.pausedInteractionProgress).to(beCloseTo(0.25))
+                    expect(cancelledFixture.dismissAnimator.resizePosition).to(beCloseTo(0))
+                    expect(cancelledFixture.sourceDelegate.dismissInteractionStates.map { String(describing: $0) }).to(equal(["begin"]))
+                    expect(cancelledFixture.destinationDelegate.dismissInteractionStates.map { String(describing: $0) }).to(equal(["begin"]))
+
+                    cancelledFixture.dismissDriver.previousInteractionProgress = 0.25
+                    cancelledFixture.dismissDriver.currentInteractionProgress = 0.6
+                    cancelledFixture.dismissDriver.currentResizePosition = 0
+                    cancelledFixture.dismissDriver.updateInteractiveTransition(progress: 0.6, position: 0, info: info)
+
+                    expect(cancelledFixture.dismissAnimator.interactionProgress).to(beCloseTo(0.6))
+                    expect(cancelledFixture.dismissAnimator.currentGestureInfo?.direction.description).to(equal("rightMiddle"))
+                    expect(cancelledFixture.sourceDelegate.dismissInteractionStates.map { String(describing: $0) }).to(equal(["begin", "update"]))
+
+                    cancelledFixture.dismissDriver.finishInteractiveTransition(isCancelled: true, progress: 0.6, position: 0, info: info)
+
+                    expect(cancelledFixture.dismissAnimator.animationTimer).to(beNil())
+                    expect(cancelledFixture.dismissAnimator.progressAnimator).notTo(beNil())
+                    expect(cancelledFixture.sourceDelegate.dismissInteractionStates.map { String(describing: $0) }).to(equal(["begin", "update", "cancel"]))
+                    expect(cancelledFixture.destinationDelegate.dismissInteractionStates.map { String(describing: $0) }).to(equal(["begin", "update", "cancel"]))
+
+                    let completedFixture = makeCoreTestTransitionFixture(style: .slide(direction: .fromRight))
+                    completedFixture.dismissDriver.currentInteractionProgress = 0.2
+                    completedFixture.dismissDriver.currentResizePosition = 0
+
+                    completedFixture.dismissDriver.beginInteractiveTransition(progress: 0.2, position: 0, info: info)
+                    completedFixture.dismissDriver.finishInteractiveTransition(isCancelled: false, progress: 0.8, position: 0, info: info)
+
+                    expect(completedFixture.dismissAnimator.animationTimer).to(beNil())
+                    expect(completedFixture.sourceDelegate.dismissInteractionStates.map { String(describing: $0) }).to(equal(["begin", "end"]))
+                    expect(completedFixture.destinationDelegate.dismissInteractionStates.map { String(describing: $0) }).to(equal(["begin", "end"]))
+                }
+
+                it("evaluates drawer resize conditions and delegates resize progress") {
+                    let resizeDelegate = CoreTestResizableDelegate()
+                    let finalDimension = FluidFinalFrameDimension(for: FluidTransitionStyle.drawer(position: .bottom),
+                                                                  portraitContainerSize: CGSize(width: 320, height: 480),
+                                                                  landscapeContainerSize: CGSize(width: 480, height: 320),
+                                                                  portraitContentSize: CGSize(width: 320, height: 240),
+                                                                  landscapeContentSize: CGSize(width: 480, height: 160),
+                                                                  portraitContentTransform: CGAffineTransform.identity,
+                                                                  landscapeContentTransform: CGAffineTransform.identity)
+                    let fixture = makeCoreTestTransitionFixture(style: .drawer(position: .bottom),
+                                                                resizableDelegate: resizeDelegate,
+                                                                finalDimension: finalDimension)
+                    let gesture = fixture.dismissDriver.observingGesture!
+
+                    fixture.dismissDriver.currentInteractionProgress = 0.5
+                    expect(fixture.dismissDriver.calculateResizePosition()).to(beLessThan(0))
+
+                    seedGesture(gesture,
+                                averageVector: CGPoint(x: 0, y: -40),
+                                velocity: CGVector(dx: 0, dy: -2_000))
+                    gesture.previousTranslation = .zero
+                    gesture.currentTranslation = CGPoint(x: 0, y: -40)
+                    fixture.dismissDriver.layout.top.constant = fixture.dismissDriver.baseConstantForResizing
+
+                    expect(fixture.dismissDriver.canBeginResizeInteraction()).to(beTrue())
+
+                    fixture.dismissDriver.currentResizePosition = 0.4
+                    fixture.dismissDriver.previousResizePosition = 0.2
+                    fixture.dismissDriver.beginInteractiveTransition(progress: 0.1, position: 0.4, info: .init())
+                    fixture.dismissDriver.updateInteractiveTransition(progress: 0.2, position: 0.6, info: .init())
+                    fixture.dismissDriver.finishInteractiveTransition(isCancelled: false, progress: 0.8, position: 1.2, info: .init())
+
+                    expect(resizeDelegate.resizeStates.map { String(describing: $0) }).to(equal(["begin", "update", "end"]))
+                    expect(resizeDelegate.resizePositions).to(equal([0.4, 0.6, 1.0]))
+                }
             }
             describe("Core animated drivers") {
                 it("configures present animators and completes a successful transition") {
@@ -1928,7 +2010,7 @@ final class UIKitSpec: QuickSpec {
     }
 }
 
-private final class CoreTestFluidViewController: UIViewController, Fluidable {}
+private final class CoreTestFluidViewController: UIViewController, Fluidable, FluidResizable {}
 
 private final class CoreTestFluidNavigationController: UINavigationController, Fluidable {}
 
@@ -2121,14 +2203,18 @@ private final class CoreTestTransitionRootDelegate: NSObject, FluidTransitionRoo
 private final class CoreTestTransitionSourceDelegate: NSObject, FluidTransitionSourceViewControllerDelegate {
     var transitionStyle: FluidTransitionStyle
     var allowInteractivePresent: Bool
+    var finalDimension: FluidFinalFrameDimension?
     var presentAnimationStates: [FluidProgressState] = []
     var dismissAnimationStates: [FluidProgressState] = []
     var presentInteractionStates: [FluidProgressState] = []
+    var dismissInteractionStates: [FluidProgressState] = []
 
     init(transitionStyle: FluidTransitionStyle = .slide(direction: .fromRight),
-         allowInteractivePresent: Bool = true) {
+         allowInteractivePresent: Bool = true,
+         finalDimension: FluidFinalFrameDimension? = nil) {
         self.transitionStyle = transitionStyle
         self.allowInteractivePresent = allowInteractivePresent
+        self.finalDimension = finalDimension
     }
 
     func transitionAllowsInteractivePresent(from source: FluidSourceViewController,
@@ -2141,6 +2227,12 @@ private final class CoreTestTransitionSourceDelegate: NSObject, FluidTransitionS
                                      to destination: FluidDestinationViewController,
                                      with navigation: FluidNavigationController?) -> FluidTransitionStyle {
         return self.transitionStyle
+    }
+
+    func transitionFinalDestinationFrameDimension(from source: FluidSourceViewController,
+                                                  to destination: FluidDestinationViewController,
+                                                  with navigation: FluidNavigationController?) -> FluidFinalFrameDimension? {
+        return self.finalDimension
     }
 
     func transitionPresentAnimationDidProgress(from source: FluidSourceViewController,
@@ -2179,6 +2271,19 @@ private final class CoreTestTransitionSourceDelegate: NSObject, FluidTransitionS
                                                  info: FluidGestureInfo) {
         self.presentInteractionStates.append(state)
     }
+
+    func transitionDismissInteractionDidProgress(from destination: FluidDestinationViewController,
+                                                 to source: FluidSourceViewController,
+                                                 with navigation: FluidNavigationController?,
+                                                 on container: UIView?,
+                                                 transitionStyle: FluidTransitionStyle,
+                                                 duration: TimeInterval,
+                                                 easing: FluidAnimatorEasing,
+                                                 state: FluidProgressState,
+                                                 progress: CGFloat,
+                                                 info: FluidGestureInfo) {
+        self.dismissInteractionStates.append(state)
+    }
 }
 
 private final class CoreTestTransitionDestinationDelegate: NSObject, FluidTransitionDestinationViewControllerDelegate {
@@ -2187,6 +2292,7 @@ private final class CoreTestTransitionDestinationDelegate: NSObject, FluidTransi
     var presentAnimationStates: [FluidProgressState] = []
     var dismissAnimationStates: [FluidProgressState] = []
     var presentInteractionStates: [FluidProgressState] = []
+    var dismissInteractionStates: [FluidProgressState] = []
 
     init(allowInteractiveDismiss: Bool = true, observedScrollViews: [UIScrollView]? = nil) {
         self.allowInteractiveDismiss = allowInteractiveDismiss
@@ -2241,6 +2347,41 @@ private final class CoreTestTransitionDestinationDelegate: NSObject, FluidTransi
                                                  info: FluidGestureInfo) {
         self.presentInteractionStates.append(state)
     }
+
+    func transitionDismissInteractionDidProgress(from destination: FluidDestinationViewController,
+                                                 to source: FluidSourceViewController,
+                                                 with navigation: FluidNavigationController?,
+                                                 on container: UIView?,
+                                                 transitionStyle: FluidTransitionStyle,
+                                                 duration: TimeInterval,
+                                                 easing: FluidAnimatorEasing,
+                                                 state: FluidProgressState,
+                                                 progress: CGFloat,
+                                                 info: FluidGestureInfo) {
+        self.dismissInteractionStates.append(state)
+    }
+}
+
+private final class CoreTestResizableDelegate: NSObject, FluidResizableTransitionDelegate {
+    var resizeStates: [FluidProgressState] = []
+    var resizePositions: [CGFloat] = []
+
+    func transitionShouldPerformResizing() -> Bool {
+        return true
+    }
+
+    func transitionMinimumMarginForResizing() -> CGFloat {
+        return 64
+    }
+
+    func transitionSnapPositionsForResizing() -> [CGFloat]? {
+        return [0, 0.5, 1]
+    }
+
+    func transitionInteractiveResizeDidProgress(state: FluidProgressState, position: CGFloat, info: FluidGestureInfo) {
+        self.resizeStates.append(state)
+        self.resizePositions.append(position)
+    }
 }
 
 private struct CoreTestTransitionFixture {
@@ -2258,12 +2399,15 @@ private struct CoreTestTransitionFixture {
 private func makeCoreTestTransitionFixture(style: FluidTransitionStyle = .slide(direction: .fromRight),
                                            allowInteractivePresent: Bool = true,
                                            allowInteractiveDismiss: Bool = true,
-                                           observedScrollViews: [UIScrollView]? = nil) -> CoreTestTransitionFixture {
+                                           observedScrollViews: [UIScrollView]? = nil,
+                                           resizableDelegate: FluidResizableTransitionDelegate? = nil,
+                                           finalDimension: FluidFinalFrameDimension? = nil) -> CoreTestTransitionFixture {
     let container = UIView(frame: CGRect(x: 0, y: 0, width: 320, height: 480))
     let sourceViewController = CoreTestFluidViewController()
     let destinationViewController = CoreTestFluidViewController()
     let sourceDelegate = CoreTestTransitionSourceDelegate(transitionStyle: style,
-                                                          allowInteractivePresent: allowInteractivePresent)
+                                                          allowInteractivePresent: allowInteractivePresent,
+                                                          finalDimension: finalDimension)
     let destinationDelegate = CoreTestTransitionDestinationDelegate(allowInteractiveDismiss: allowInteractiveDismiss,
                                                                     observedScrollViews: observedScrollViews)
     let presentAnimator = FluidTransitionViewAnimator()
@@ -2275,6 +2419,7 @@ private func makeCoreTestTransitionFixture(style: FluidTransitionStyle = .slide(
     destinationViewController.view.frame = container.bounds
     sourceViewController.fluidDelegate = sourceDelegate
     destinationViewController.fluidDelegate = destinationDelegate
+    destinationViewController.fluidResizableDelegate = resizableDelegate
     container.addSubview(sourceViewController.view)
 
     try! presentDriver.configureParameters(driverType: .present,

--- a/Tests/UIKitSpec.swift
+++ b/Tests/UIKitSpec.swift
@@ -1230,6 +1230,121 @@ final class UIKitSpec: QuickSpec {
                         .to(equal(CGRect(x: 0, y: 0, width: 228, height: 480)))
                 }
 
+                it("activates, applies, and deactivates transition edge constraints") {
+                    let container = UIView(frame: CGRect(x: 0, y: 0, width: 320, height: 480))
+                    let content = UIView(frame: .zero)
+                    content.translatesAutoresizingMaskIntoConstraints = false
+                    container.addSubview(content)
+                    var layout = FluidLayout(for: .slide(direction: .fromBottom),
+                                             presentationType: .transition,
+                                             container: container,
+                                             content: content,
+                                             containerSize: CGSize(width: 320, height: 480),
+                                             contentSize: CGSize(width: 240, height: 300))
+
+                    expect(String(describing: FluidLayout.FluidPresentationType.navigation)).to(equal("navigation"))
+                    expect(String(describing: FluidLayout.FluidPresentationType.transition)).to(equal("transition"))
+                    expect(layout.isFullScreen).to(beFalse())
+                    expect(layout.top.isActive).to(beFalse())
+                    expect(layout.bottom.isActive).to(beFalse())
+                    expect(layout.left.isActive).to(beFalse())
+                    expect(layout.right.isActive).to(beFalse())
+
+                    layout.activate(type: .transition)
+
+                    expect(layout.top.isActive).to(beTrue())
+                    expect(layout.bottom.isActive).to(beTrue())
+                    expect(layout.left.isActive).to(beTrue())
+                    expect(layout.right.isActive).to(beTrue())
+
+                    layout.apply(top: 0, bottom: 0, left: 0, right: 0)
+
+                    expect(layout.isFullScreen).to(beTrue())
+
+                    layout.apply(top: 12, right: 24)
+
+                    expect(layout.top.constant).to(beCloseTo(12))
+                    expect(layout.bottom.constant).to(beCloseTo(0))
+                    expect(layout.left.constant).to(beCloseTo(0))
+                    expect(layout.right.constant).to(beCloseTo(24))
+
+                    layout.deactivate(type: .transition)
+
+                    expect(layout.top.isActive).to(beFalse())
+                    expect(layout.bottom.isActive).to(beFalse())
+                    expect(layout.left.isActive).to(beFalse())
+                    expect(layout.right.isActive).to(beFalse())
+
+                    let navigationLayout = FluidLayout(for: .scale,
+                                                       presentationType: .navigation,
+                                                       container: container,
+                                                       content: content,
+                                                       containerSize: CGSize(width: 320, height: 480),
+                                                       contentSize: nil)
+
+                    expect(navigationLayout.isFullScreen).to(beTrue())
+                    navigationLayout.deactivate(type: .navigation)
+                }
+
+                it("creates drawer edge anchors for each exposed side") {
+                    let container = UIView(frame: CGRect(x: 0, y: 0, width: 320, height: 480))
+                    let content = UIView(frame: .zero)
+                    container.addSubview(content)
+                    let containerSize = CGSize(width: 320, height: 480)
+                    let contentSize = CGSize(width: 200, height: 160)
+
+                    let top = FluidLayout.topEdgeDrawerAnchors(container, content, containerSize, contentSize)
+                    let bottom = FluidLayout.bottomEdgeDrawerAnchors(container, content, containerSize, contentSize)
+                    let left = FluidLayout.leftEdgeDrawerAnchors(container, content, containerSize, contentSize)
+                    let right = FluidLayout.rightEdgeDrawerAnchors(container, content, containerSize, contentSize)
+
+                    expect(top.top.constant).to(beCloseTo(0))
+                    expect(top.bottom.constant).to(beCloseTo(320))
+                    expect(top.left.constant).to(beCloseTo(60))
+                    expect(top.right.constant).to(beCloseTo(60))
+
+                    expect(bottom.top.constant).to(beCloseTo(320))
+                    expect(bottom.bottom.constant).to(beCloseTo(0))
+                    expect(bottom.left.constant).to(beCloseTo(60))
+                    expect(bottom.right.constant).to(beCloseTo(60))
+
+                    expect(left.top.constant).to(beCloseTo(160))
+                    expect(left.bottom.constant).to(beCloseTo(160))
+                    expect(left.left.constant).to(beCloseTo(0))
+                    expect(left.right.constant).to(beCloseTo(120))
+
+                    expect(right.top.constant).to(beCloseTo(160))
+                    expect(right.bottom.constant).to(beCloseTo(160))
+                    expect(right.left.constant).to(beCloseTo(120))
+                    expect(right.right.constant).to(beCloseTo(0))
+                }
+
+                it("creates fluid size constants for idiom and transition state") {
+                    let portrait = CGSize(width: 320, height: 480)
+                    let landscape = CGSize(width: 600, height: 400)
+
+                    expect(FluidLayout.sizeConstant(for: .fluid(behavior: .scale),
+                                                    containerSize: portrait,
+                                                    idiom: .phone,
+                                                    isInitial: true))
+                        .to(equal(CGSize(width: 173, height: 346)))
+                    expect(FluidLayout.sizeConstant(for: .fluid(behavior: .scale),
+                                                    containerSize: portrait,
+                                                    idiom: .phone,
+                                                    isInitial: false))
+                        .to(equal(portrait))
+                    expect(FluidLayout.sizeConstant(for: .fluid(behavior: .scale),
+                                                    containerSize: landscape,
+                                                    idiom: .pad,
+                                                    isInitial: true))
+                        .to(equal(CGSize(width: 324, height: 288)))
+                    expect(FluidLayout.sizeConstant(for: .fluid(behavior: .scale),
+                                                    containerSize: landscape,
+                                                    idiom: .pad,
+                                                    isInitial: false))
+                        .to(equal(landscape))
+                }
+
                 it("creates center and size constraints for full screen content") {
                     let container = UIView(frame: CGRect(x: 0, y: 0, width: 320, height: 480))
                     let content = UIView(frame: .zero)

--- a/Tests/UIKitSpec.swift
+++ b/Tests/UIKitSpec.swift
@@ -95,6 +95,25 @@ final class UIKitSpec: QuickSpec {
         }
     }
 
+    class TestAdaptiveInterface: AdaptiveInterface {
+        var traitCollection: UITraitCollection = UITraitCollection()
+        var adaptiveElements: [AdaptiveElement] = []
+    }
+
+    class AdaptiveUpdateRecorder {
+        var labels: [String] = []
+    }
+
+    struct RecordingAdaptiveElement: AdaptiveElement {
+        let traitCollection: UITraitCollection
+        let label: String
+        let recorder: AdaptiveUpdateRecorder
+
+        func update(for incomingTraitCollection: UITraitCollection) {
+            self.recorder.labels.append(self.label)
+        }
+    }
+
     class TestBlurredBackgroundView: FluidBlurredBackgroundView {
         var blurRadiusValues: [CGFloat] = []
         var colorTintValues: [UIColor?] = []
@@ -2405,6 +2424,174 @@ final class UIKitSpec: QuickSpec {
                 expect(scrollView.maxScrollableY).to(equal(-1000))
                 expect(scrollView.normalizedContentOffset).to(equal(CGPoint(x: 0, y: 100)))
                 expect(scrollView.effectiveContentInset).to(equal(UIEdgeInsets(top: 0, left: 0, bottom: 0, right: 0)))
+            }
+        }
+        describe("AdaptiveLayout") {
+            it("generates trait collections from adaptive attributes") {
+                expect(Idiom.phone.generateTraitCollection().userInterfaceIdiom).to(equal(.phone))
+                expect(Idiom.pad.generateTraitCollection().userInterfaceIdiom).to(equal(.pad))
+                expect(Idiom.tv.generateTraitCollection().userInterfaceIdiom).to(equal(.tv))
+                expect(Idiom.carPlay.generateTraitCollection().userInterfaceIdiom).to(equal(.carPlay))
+
+                expect(Scale.oneX.generateTraitCollection().displayScale).to(equal(1))
+                expect(Scale.twoX.generateTraitCollection().displayScale).to(equal(2))
+                expect(Scale.threeX.generateTraitCollection().displayScale).to(equal(3))
+                expect(Scale.fourX.generateTraitCollection().displayScale).to(equal(4))
+
+                expect(SizeClass.horizontalCompact.generateTraitCollection().horizontalSizeClass).to(equal(.compact))
+                expect(SizeClass.horizontalRegular.generateTraitCollection().horizontalSizeClass).to(equal(.regular))
+                expect(SizeClass.verticalCompact.generateTraitCollection().verticalSizeClass).to(equal(.compact))
+                expect(SizeClass.verticalRegular.generateTraitCollection().verticalSizeClass).to(equal(.regular))
+
+                expect(ForceTouch.available.generateTraitCollection().forceTouchCapability).to(equal(.available))
+                expect(ForceTouch.unavailable.generateTraitCollection().forceTouchCapability).to(equal(.unavailable))
+
+                if #available(iOS 10.0, *) {
+                    expect(LayoutDirection.leftToRight.generateTraitCollection().layoutDirection).to(equal(.leftToRight))
+                    expect(LayoutDirection.rightToLeft.generateTraitCollection().layoutDirection).to(equal(.rightToLeft))
+                    expect(DisplayGamut.SRGB.generateTraitCollection().displayGamut).to(equal(.SRGB))
+                    expect(DisplayGamut.P3.generateTraitCollection().displayGamut).to(equal(.P3))
+
+                    let sizeCategories: [(SizeCategory, UIContentSizeCategory)] = [
+                        (.extraSmall, .extraSmall),
+                        (.small, .small),
+                        (.medium, .medium),
+                        (.large, .large),
+                        (.extraLarge, .extraLarge),
+                        (.extraExtraLarge, .extraExtraLarge),
+                        (.extraExtraExtraLarge, .extraExtraExtraLarge),
+                        (.accessibilityMedium, .accessibilityMedium),
+                        (.accessibilityLarge, .accessibilityLarge),
+                        (.accessibilityExtraLarge, .accessibilityExtraLarge),
+                        (.accessibilityExtraExtraLarge, .accessibilityExtraExtraLarge),
+                        (.accessibilityExtraExtraExtraLarge, .accessibilityExtraExtraExtraLarge),
+                    ]
+
+                    sizeCategories.forEach { (attribute, expectedCategory) in
+                        expect(attribute.generateTraitCollection().preferredContentSizeCategory).to(equal(expectedCategory))
+                    }
+                }
+            }
+
+            it("maps trait collections back to adaptive attributes") {
+                let attributes: [AdaptiveAttribute] = [
+                    Idiom.pad,
+                    Scale.twoX,
+                    SizeClass.horizontalCompact,
+                    SizeClass.verticalRegular,
+                    ForceTouch.available,
+                    LayoutDirection.rightToLeft,
+                    SizeCategory.accessibilityLarge,
+                    DisplayGamut.P3,
+                ]
+                let traits = UITraitCollection(attributes: attributes)
+
+                expect(traits.contains(Idiom.pad)).to(beTrue())
+                expect(traits.contains(Idiom.phone)).to(beFalse())
+                expect(traits.contains(Scale.twoX)).to(beTrue())
+                expect(traits.contains(SizeClass.horizontalCompact)).to(beTrue())
+                expect(traits.contains(SizeClass.verticalRegular)).to(beTrue())
+                expect(traits.contains(ForceTouch.available)).to(beTrue())
+                expect(traits.contains(LayoutDirection.rightToLeft)).to(beTrue())
+                expect(traits.contains(SizeCategory.accessibilityLarge)).to(beTrue())
+                expect(traits.contains(DisplayGamut.P3)).to(beTrue())
+
+                let adaptiveAttributes = traits.adaptiveAttributes
+
+                expect(adaptiveAttributes.contains { ($0 as? Idiom) == .pad }).to(beTrue())
+                expect(adaptiveAttributes.contains { ($0 as? Scale) == .twoX }).to(beTrue())
+                expect(adaptiveAttributes.contains { ($0 as? SizeClass) == .horizontalCompact }).to(beTrue())
+                expect(adaptiveAttributes.contains { ($0 as? SizeClass) == .verticalRegular }).to(beTrue())
+                expect(adaptiveAttributes.contains { ($0 as? ForceTouch) == .available }).to(beTrue())
+                expect(adaptiveAttributes.contains { ($0 as? LayoutDirection) == .rightToLeft }).to(beTrue())
+                expect(adaptiveAttributes.contains { ($0 as? SizeCategory) == .accessibilityLarge }).to(beTrue())
+                expect(adaptiveAttributes.contains { ($0 as? DisplayGamut) == .P3 }).to(beTrue())
+            }
+
+            it("updates behaviors, constraints, and views through an adaptive interface") {
+                let adaptiveInterface = TestAdaptiveInterface()
+                let parent = UIView()
+                let directChild = UIView()
+                let attributesChild = UIView()
+                let attributeChild = UIView()
+                let directWidth = directChild.widthAnchor.constraint(equalToConstant: 44)
+                let attributesWidth = attributesChild.widthAnchor.constraint(equalToConstant: 45)
+                let attributeWidth = attributeChild.widthAnchor.constraint(equalToConstant: 46)
+                var behaviorCount = 0
+                var counterBehaviorCount = 0
+
+                adaptiveInterface.addBehavior(for: UITraitCollection(attributes: [Idiom.pad]),
+                                              behavior: { behaviorCount += 1 },
+                                              counterBehavior: { counterBehaviorCount += 1 })
+                adaptiveInterface.addBehavior(for: [Scale.twoX],
+                                              behavior: { behaviorCount += 1 },
+                                              counterBehavior: { counterBehaviorCount += 1 })
+                adaptiveInterface.addBehavior(for: SizeClass.horizontalRegular,
+                                              behavior: { behaviorCount += 1 },
+                                              counterBehavior: { counterBehaviorCount += 1 })
+
+                adaptiveInterface.addConstraints(for: UITraitCollection(attributes: [Idiom.pad]),
+                                                 constraints: [directWidth])
+                adaptiveInterface.addConstraints(for: [Scale.twoX],
+                                                 constraints: attributesWidth)
+                adaptiveInterface.addConstraints(for: SizeClass.horizontalRegular,
+                                                 constraints: attributeWidth)
+
+                adaptiveInterface.addView(for: UITraitCollection(attributes: [Idiom.pad]),
+                                          view: directChild,
+                                          parent: parent,
+                                          constraints: [])
+                adaptiveInterface.addView(for: [Scale.twoX],
+                                          view: attributesChild,
+                                          parent: parent,
+                                          constraints: [])
+                adaptiveInterface.addView(for: SizeClass.horizontalRegular,
+                                          view: attributeChild,
+                                          parent: parent,
+                                          constraints: [])
+
+                let nonMatchingTraits = UITraitCollection(attributes: [Idiom.phone, Scale.threeX, SizeClass.horizontalCompact])
+                adaptiveInterface.update(for: nonMatchingTraits)
+
+                expect(behaviorCount).to(equal(0))
+                expect(counterBehaviorCount).to(equal(3))
+                expect(directWidth.isActive).to(beFalse())
+                expect(attributesWidth.isActive).to(beFalse())
+                expect(attributeWidth.isActive).to(beFalse())
+                expect(directChild.superview).to(beNil())
+                expect(attributesChild.superview).to(beNil())
+                expect(attributeChild.superview).to(beNil())
+
+                let matchingTraits = UITraitCollection(attributes: [Idiom.pad, Scale.twoX, SizeClass.horizontalRegular])
+                adaptiveInterface.update(for: matchingTraits)
+
+                expect(behaviorCount).to(equal(3))
+                expect(counterBehaviorCount).to(equal(3))
+                expect(directWidth.isActive).to(beTrue())
+                expect(attributesWidth.isActive).to(beTrue())
+                expect(attributeWidth.isActive).to(beTrue())
+                expect(directChild.superview).to(beIdenticalTo(parent))
+                expect(attributesChild.superview).to(beIdenticalTo(parent))
+                expect(attributeChild.superview).to(beIdenticalTo(parent))
+            }
+
+            it("updates nonmatching adaptive elements before matching elements") {
+                let adaptiveInterface = TestAdaptiveInterface()
+                let recorder = AdaptiveUpdateRecorder()
+                let matchingTraits = UITraitCollection(attributes: [Idiom.pad])
+
+                adaptiveInterface.adaptiveElements = [
+                    RecordingAdaptiveElement(traitCollection: matchingTraits,
+                                             label: "matching",
+                                             recorder: recorder),
+                    RecordingAdaptiveElement(traitCollection: UITraitCollection(attributes: [Idiom.phone]),
+                                             label: "nonmatching",
+                                             recorder: recorder),
+                ]
+
+                adaptiveInterface.update(for: matchingTraits)
+
+                expect(recorder.labels).to(equal(["nonmatching", "matching"]))
             }
         }
         describe("UIBezierPath") {

--- a/Tests/UIKitSpec.swift
+++ b/Tests/UIKitSpec.swift
@@ -525,6 +525,116 @@ final class UIKitSpec: QuickSpec {
                     expect(FluidShadowLayer.needsDisplay(forKey: "isTransparentBackground")).to(beTrue())
                 }
             }
+            describe("Navigation interactive animator") {
+                it("interpolates dismiss frames and shadow properties") {
+                    let fixture = makeCoreTestNavigationFixture(style: .slide(direction: .fromBottom))
+                    let animator = fixture.dismissAnimator
+                    let shadowView = FluidShadowView(shadowCornerRadius: 0,
+                                                     shadowRoundingCorners: nil,
+                                                     shadowOpacity: 0,
+                                                     shadowColor: UIColor.black.cgColor,
+                                                     shadowRadius: 0,
+                                                     shadowOffset: .zero,
+                                                     isTransparentBackground: false)
+
+                    fixture.container.addSubview(shadowView)
+                    animator.parameters.shadowView = shadowView
+                    shadowView.layer.mask = CAShapeLayer()
+
+                    animator.interactionDidStart(progress: 0, position: 0, info: FluidGestureInfo())
+                    defer {
+                        animator.animationTimer?.stop()
+                        animator.animationTimer = nil
+                    }
+
+                    let fromFrame = animator.finalDimension.frame()
+                    let toFrame = animator.initialDimension.frame()
+                    var fromStyle = FluidFinalFrameStyle(cornerRadius: 24,
+                                                         cornerStyle: .top,
+                                                         shadowColor: UIColor.red.cgColor,
+                                                         shadowOpacity: 0.8,
+                                                         shadowRadius: 10,
+                                                         shadowOffset: CGSize(width: 4, height: 2))
+                    fromStyle.isTransparentBackground = true
+                    let toStyle = FluidInitialFrameStyle(cornerRadius: 4,
+                                                         shadowColor: UIColor.blue.cgColor,
+                                                         shadowOpacity: 0.2,
+                                                         shadowRadius: 2,
+                                                         shadowOffset: CGSize(width: -2, height: 6))
+
+                    animator.storedFromStyle = fromStyle
+                    animator.storedToStyle = toStyle
+                    animator.interactionProgress = 0.5
+                    animator.animationTimerDidUpdate()
+
+                    let expectedFrame = fromFrame - (fromFrame - toFrame) * 0.5
+
+                    expect(animator.layoutContainerView.frame).to(equal(expectedFrame))
+                    expect(animator.layoutContainerView.layer.cornerRadius).to(beCloseTo(14))
+                    expect(animator.backgroundView?.visibility).to(beCloseTo(0.5))
+                    expect(shadowView.layer.frame).to(equal(expectedFrame))
+                    expect(shadowView.layer.cornerRadius).to(beCloseTo(14))
+                    expect(CGFloat(shadowView.layer.shadowOpacity)).to(beCloseTo(0.5, within: 0.001))
+                    expect(shadowView.layer.shadowRadius).to(beCloseTo(6))
+                    expect(shadowView.layer.shadowOffset).to(equal(CGSize(width: 1, height: 4)))
+                    expect(shadowView.layer.shadowPath).notTo(beNil())
+                    expect((shadowView.layer.mask as? CAShapeLayer)?.path).notTo(beNil())
+                }
+            }
+            describe("Navigation scroll observer") {
+                it("observes, locks, and restores scroll state") {
+                    let fixture = makeCoreTestNavigationFixture(style: .slide(direction: .fromBottom))
+                    let scrollView = UIScrollView(frame: CGRect(x: 0, y: 0, width: 120, height: 80))
+                    let observer = FluidNavigationScrollObserver(view: scrollView)
+
+                    scrollView.contentSize = CGSize(width: 120, height: 240)
+                    scrollView.contentOffset = CGPoint(x: 0, y: 12)
+                    scrollView.showsVerticalScrollIndicator = true
+                    scrollView.showsHorizontalScrollIndicator = true
+                    observer.registerParameters(parameters: fixture.dismissDriver.parameters)
+
+                    observer.startObserving()
+
+                    expect(observer.panGestureRecognizer).notTo(beNil())
+                    expect(observer.offsetObservation).notTo(beNil())
+                    expect(observer.gestureRecognizerShouldBegin(observer.panGestureRecognizer)).to(beTrue())
+                    expect(observer.gestureRecognizer(observer.panGestureRecognizer,
+                                                      shouldRecognizeSimultaneouslyWith: UIPanGestureRecognizer()))
+                        .to(beTrue())
+                    expect(observer.description).to(contain("FluidScrollObservable"))
+
+                    observer.updateScroll(progress: 0.4, position: 0, state: .dismissing)
+
+                    expect(observer.isTransitioning).to(beTrue())
+                    expect(observer.lockedContentOffset).to(equal(CGPoint(x: 0, y: 12)))
+                    expect(scrollView.showsVerticalScrollIndicator).to(beFalse())
+                    expect(scrollView.showsHorizontalScrollIndicator).to(beFalse())
+
+                    scrollView.contentOffset = CGPoint(x: 0, y: -20)
+                    observer.contentOffsetDidChange(oldValue: CGPoint(x: 0, y: -20))
+
+                    expect(scrollView.contentOffset).to(equal(CGPoint(x: 0, y: 12)))
+
+                    observer.updateScroll(progress: 0, position: 0, state: .none)
+
+                    expect(observer.isTransitioning).to(beFalse())
+                    expect(observer.lockedContentOffset).to(beNil())
+                    expect(scrollView.showsVerticalScrollIndicator).to(beTrue())
+                    expect(scrollView.showsHorizontalScrollIndicator).to(beTrue())
+
+                    observer.disableInteraction()
+                    expect(scrollView.isUserInteractionEnabled).to(beFalse())
+                    expect(scrollView.isScrollEnabled).to(beFalse())
+                    observer.enableInteraction()
+                    expect(scrollView.isUserInteractionEnabled).to(beTrue())
+                    expect(scrollView.isScrollEnabled).to(beTrue())
+
+                    observer.stopObserving()
+
+                    expect(observer.panGestureRecognizer).to(beNil())
+                    expect(observer.offsetObservation).to(beNil())
+                }
+            }
             describe("FluidLayoutEdgeConstant") {
                 it("calculates edge constants from container size and frame") {
                     let constants = FluidLayoutEdgeConstant(
@@ -921,9 +1031,95 @@ private final class CoreTestNavigationRootDelegate: NSObject, FluidNavigationRoo
     func navigationDismissInteractionDidProgress(from destination: FluidDestinationViewController, to source: FluidSourceViewController, with navigation: FluidNavigationController?, on container: UIView?, navigationStyle: FluidNavigationStyle, duration: TimeInterval, easing: FluidAnimatorEasing, state: FluidProgressState, progress: CGFloat, info: FluidGestureInfo) {}
 }
 
-private final class CoreTestNavigationSourceDelegate: NSObject, FluidNavigationSourceViewControllerDelegate {}
+private final class CoreTestNavigationSourceDelegate: NSObject, FluidNavigationSourceViewControllerDelegate {
+    var navigationStyle: FluidNavigationStyle
+
+    init(navigationStyle: FluidNavigationStyle = .slide(direction: .fromRight)) {
+        self.navigationStyle = navigationStyle
+    }
+
+    func navigationPresentationStyle(from source: FluidSourceViewController,
+                                     to destination: FluidDestinationViewController,
+                                     with navigation: FluidNavigationController?) -> FluidNavigationStyle {
+        return self.navigationStyle
+    }
+
+    func navigationBackgroundStyle(from source: FluidSourceViewController,
+                                   to destination: FluidDestinationViewController,
+                                   with navigation: FluidNavigationController?) -> FluidBackgroundStyle {
+        return .dim(color: UIColor.black.withAlphaComponent(0.4))
+    }
+}
 
 private final class CoreTestNavigationDestinationDelegate: NSObject, FluidNavigationDestinationViewControllerDelegate {}
+
+private struct CoreTestNavigationFixture {
+    let container: UIView
+    let navigationController: CoreTestFluidNavigationController
+    let sourceViewController: CoreTestFluidViewController
+    let destinationViewController: CoreTestFluidViewController
+    let rootDelegate: CoreTestNavigationRootDelegate
+    let sourceDelegate: CoreTestNavigationSourceDelegate
+    let destinationDelegate: CoreTestNavigationDestinationDelegate
+    let presentAnimator: FluidNavigationViewAnimator
+    let dismissAnimator: FluidNavigationViewAnimator
+    let presentDriver: FluidNavigationPresentDriver
+    let dismissDriver: FluidNavigationDismissDriver
+}
+
+private func makeCoreTestNavigationFixture(style: FluidNavigationStyle = .slide(direction: .fromRight)) -> CoreTestNavigationFixture {
+    let container = UIView(frame: CGRect(x: 0, y: 0, width: 320, height: 480))
+    let sourceViewController = CoreTestFluidViewController()
+    let destinationViewController = CoreTestFluidViewController()
+    let navigationController = CoreTestFluidNavigationController(rootViewController: sourceViewController)
+    let rootDelegate = CoreTestNavigationRootDelegate()
+    let sourceDelegate = CoreTestNavigationSourceDelegate(navigationStyle: style)
+    let destinationDelegate = CoreTestNavigationDestinationDelegate()
+    let presentAnimator = FluidNavigationViewAnimator()
+    let dismissAnimator = FluidNavigationViewAnimator()
+    let presentDriver = FluidNavigationPresentDriver(presentAnimator)
+    let dismissDriver = FluidNavigationDismissDriver(dismissAnimator)
+
+    navigationController.view.frame = container.bounds
+    sourceViewController.view.frame = container.bounds
+    destinationViewController.view.frame = container.bounds
+    navigationController.fluidDelegate = rootDelegate
+    sourceViewController.fluidDelegate = sourceDelegate
+    destinationViewController.fluidDelegate = destinationDelegate
+    container.addSubview(navigationController.view)
+    container.addSubview(destinationViewController.view)
+
+    try! presentDriver.configureParameters(driverType: .present,
+                                           animationType: .present,
+                                           context: nil,
+                                           container: container,
+                                           source: sourceViewController,
+                                           destination: destinationViewController,
+                                           initialContainerSize: container.bounds.size,
+                                           finalContainerSize: container.bounds.size,
+                                           shouldInsertSubview: true)
+    try! dismissDriver.configureParameters(driverType: .dismiss,
+                                           animationType: .dismiss,
+                                           context: nil,
+                                           container: container,
+                                           source: sourceViewController,
+                                           destination: destinationViewController,
+                                           initialContainerSize: container.bounds.size,
+                                           finalContainerSize: container.bounds.size,
+                                           shouldInsertSubview: true)
+
+    return CoreTestNavigationFixture(container: container,
+                                     navigationController: navigationController,
+                                     sourceViewController: sourceViewController,
+                                     destinationViewController: destinationViewController,
+                                     rootDelegate: rootDelegate,
+                                     sourceDelegate: sourceDelegate,
+                                     destinationDelegate: destinationDelegate,
+                                     presentAnimator: presentAnimator,
+                                     dismissAnimator: dismissAnimator,
+                                     presentDriver: presentDriver,
+                                     dismissDriver: dismissDriver)
+}
 
 private final class CoreTestTransitionRootDelegate: NSObject, FluidTransitionRootNavigationControllerDelegate {
     func transitionPresentAnimationDidProgress(from source: FluidSourceViewController, to destination: FluidDestinationViewController, with navigation: FluidNavigationController?, on container: UIView?, transitionStyle: FluidTransitionStyle, duration: TimeInterval, easing: FluidAnimatorEasing, state: FluidProgressState, progress: CGFloat) {}

--- a/Tests/UIKitSpec.swift
+++ b/Tests/UIKitSpec.swift
@@ -635,6 +635,124 @@ final class UIKitSpec: QuickSpec {
                     expect(observer.offsetObservation).to(beNil())
                 }
             }
+            describe("Transition interactive animator") {
+                it("interpolates dismiss frames and shadow properties") {
+                    let fixture = makeCoreTestTransitionFixture(style: .slide(direction: .fromBottom))
+                    let animator = fixture.dismissAnimator
+                    let backgroundView = FluidDimmedBackgroundView(color: .black)
+                    let shadowView = FluidShadowView(shadowCornerRadius: 0,
+                                                     shadowRoundingCorners: nil,
+                                                     shadowOpacity: 0,
+                                                     shadowColor: UIColor.black.cgColor,
+                                                     shadowRadius: 0,
+                                                     shadowOffset: .zero,
+                                                     isTransparentBackground: false)
+
+                    fixture.container.insertSubview(backgroundView, belowSubview: animator.layoutContainerView)
+                    fixture.container.addSubview(shadowView)
+                    animator.parameters.backgroundView = backgroundView
+                    animator.parameters.shadowView = shadowView
+                    shadowView.layer.mask = CAShapeLayer()
+
+                    animator.interactionDidStart(progress: 0, position: 0, info: FluidGestureInfo())
+                    defer {
+                        animator.animationTimer?.stop()
+                        animator.animationTimer = nil
+                    }
+
+                    let fromFrame = animator.finalDimension.frame()
+                    let toFrame = animator.initialDimension.frame()
+                    var fromStyle = FluidFinalFrameStyle(cornerRadius: 24,
+                                                         cornerStyle: .top,
+                                                         shadowColor: UIColor.red.cgColor,
+                                                         shadowOpacity: 0.8,
+                                                         shadowRadius: 10,
+                                                         shadowOffset: CGSize(width: 4, height: 2))
+                    fromStyle.isTransparentBackground = true
+                    let toStyle = FluidInitialFrameStyle(cornerRadius: 4,
+                                                         shadowColor: UIColor.blue.cgColor,
+                                                         shadowOpacity: 0.2,
+                                                         shadowRadius: 2,
+                                                         shadowOffset: CGSize(width: -2, height: 6))
+
+                    animator.storedFromStyle = fromStyle
+                    animator.storedToStyle = toStyle
+                    animator.interactionProgress = 0.5
+                    animator.animationTimerDidUpdate()
+
+                    let expectedFrame = fromFrame - (fromFrame - toFrame) * 0.5
+                    let expectedEdges = FluidLayoutEdgeConstant(size: animator.initialContainerSize,
+                                                                frame: expectedFrame)
+
+                    expect(animator.layout.top.constant).to(beCloseTo(expectedEdges.top))
+                    expect(animator.layout.bottom.constant).to(beCloseTo(expectedEdges.bottom))
+                    expect(animator.layout.left.constant).to(beCloseTo(expectedEdges.left))
+                    expect(animator.layout.right.constant).to(beCloseTo(expectedEdges.right))
+                    expect(animator.layoutContainerView.layer.cornerRadius).to(beCloseTo(14))
+                    expect(animator.backgroundView?.visibility).to(beCloseTo(0.5))
+                    expect(shadowView.layer.frame).to(equal(expectedFrame))
+                    expect(shadowView.layer.cornerRadius).to(beCloseTo(14))
+                    expect(CGFloat(shadowView.layer.shadowOpacity)).to(beCloseTo(0.5, within: 0.001))
+                    expect(shadowView.layer.shadowRadius).to(beCloseTo(6))
+                    expect(shadowView.layer.shadowOffset).to(equal(CGSize(width: 1, height: 4)))
+                    expect(shadowView.layer.shadowPath).notTo(beNil())
+                    expect((shadowView.layer.mask as? CAShapeLayer)?.path).notTo(beNil())
+                }
+            }
+            describe("Transition scroll observer") {
+                it("observes, locks, and restores scroll state") {
+                    let fixture = makeCoreTestTransitionFixture(style: .slide(direction: .fromBottom))
+                    let scrollView = UIScrollView(frame: CGRect(x: 0, y: 0, width: 120, height: 80))
+                    let observer = FluidTransitionScrollObserver(view: scrollView)
+
+                    scrollView.contentSize = CGSize(width: 120, height: 240)
+                    scrollView.contentOffset = CGPoint(x: 0, y: 12)
+                    scrollView.showsVerticalScrollIndicator = true
+                    scrollView.showsHorizontalScrollIndicator = true
+                    observer.registerParameters(parameters: fixture.dismissDriver.parameters)
+
+                    observer.startObserving()
+
+                    expect(observer.panGestureRecognizer).notTo(beNil())
+                    expect(observer.offsetObservation).notTo(beNil())
+                    expect(observer.gestureRecognizerShouldBegin(observer.panGestureRecognizer)).to(beTrue())
+                    expect(observer.gestureRecognizer(observer.panGestureRecognizer,
+                                                      shouldRecognizeSimultaneouslyWith: UIPanGestureRecognizer()))
+                        .to(beTrue())
+                    expect(observer.description).to(contain("FluidScrollObservable"))
+
+                    observer.updateScroll(progress: 0.4, position: 0, state: .dismissing)
+
+                    expect(observer.isTransitioning).to(beTrue())
+                    expect(observer.lockedContentOffset).to(equal(CGPoint(x: 0, y: 12)))
+                    expect(scrollView.showsVerticalScrollIndicator).to(beFalse())
+                    expect(scrollView.showsHorizontalScrollIndicator).to(beFalse())
+
+                    scrollView.contentOffset = CGPoint(x: 0, y: -20)
+                    observer.contentOffsetDidChange(oldValue: CGPoint(x: 0, y: -20))
+
+                    expect(scrollView.contentOffset).to(equal(CGPoint(x: 0, y: 12)))
+
+                    observer.updateScroll(progress: 0, position: 0, state: .none)
+
+                    expect(observer.isTransitioning).to(beFalse())
+                    expect(observer.lockedContentOffset).to(beNil())
+                    expect(scrollView.showsVerticalScrollIndicator).to(beTrue())
+                    expect(scrollView.showsHorizontalScrollIndicator).to(beTrue())
+
+                    observer.disableInteraction()
+                    expect(scrollView.isUserInteractionEnabled).to(beFalse())
+                    expect(scrollView.isScrollEnabled).to(beFalse())
+                    observer.enableInteraction()
+                    expect(scrollView.isUserInteractionEnabled).to(beTrue())
+                    expect(scrollView.isScrollEnabled).to(beTrue())
+
+                    observer.stopObserving()
+
+                    expect(observer.panGestureRecognizer).to(beNil())
+                    expect(observer.offsetObservation).to(beNil())
+                }
+            }
             describe("FluidLayoutEdgeConstant") {
                 it("calculates edge constants from container size and frame") {
                     let constants = FluidLayoutEdgeConstant(

--- a/Tests/UIKitSpec.swift
+++ b/Tests/UIKitSpec.swift
@@ -283,6 +283,35 @@ final class UIKitSpec: QuickSpec {
                     expect(controller.fluid.transitionDismissDriver).to(beIdenticalTo(transitionDelegate.dismissDriver))
                 }
             }
+            describe("FluidViewControllerTransitioningDelegate") {
+                it("selects transition drivers for valid source and destination roles") {
+                    let delegate = FluidViewControllerTransitioningDelegate()
+                    let source = CoreTestFluidViewController()
+                    let destination = CoreTestFluidViewController()
+                    let plainDestination = CoreTestFluidViewController()
+                    let sourceDelegate = CoreTestTransitionSourceDelegate()
+                    let destinationDelegate = CoreTestTransitionDestinationDelegate()
+
+                    source.fluidDelegate = sourceDelegate
+                    destination.fluidDelegate = destinationDelegate
+
+                    expect(delegate.animationController(forPresented: destination,
+                                                        presenting: source,
+                                                        source: source) as? FluidTransitionPresentDriver)
+                        .to(beIdenticalTo(delegate.presentDriver))
+                    expect(delegate.animationController(forPresented: plainDestination,
+                                                        presenting: source,
+                                                        source: source)).to(beNil())
+                    expect(delegate.animationController(forDismissed: destination) as? FluidTransitionDismissDriver)
+                        .to(beIdenticalTo(delegate.dismissDriver))
+                    expect(delegate.interactionControllerForPresentation(using: delegate.presentDriver) as? FluidTransitionPresentDriver)
+                        .to(beIdenticalTo(delegate.presentDriver))
+                    expect(delegate.interactionControllerForDismissal(using: delegate.dismissDriver)).to(beNil())
+                    delegate.dismissDriver.isInteracting = true
+                    expect(delegate.interactionControllerForDismissal(using: delegate.dismissDriver) as? FluidTransitionDismissDriver)
+                        .to(beIdenticalTo(delegate.dismissDriver))
+                }
+            }
             describe("Core interactive drivers") {
                 it("propagates present interaction lifecycle and stores animator gesture info") {
                     let fixture = makeCoreTestTransitionFixture()
@@ -313,6 +342,25 @@ final class UIKitSpec: QuickSpec {
                     expect(fixture.presentAnimator.currentGestureInfo?.direction.description).to(equal("leftMiddle"))
                     expect(fixture.sourceDelegate.presentInteractionStates.map { String(describing: $0) }).to(equal(["begin", "update", "cancel"]))
                     expect(fixture.destinationDelegate.presentInteractionStates.map { String(describing: $0) }).to(equal(["begin", "update", "cancel"]))
+                    expect(fixture.presentDriver.observingGesture).to(beNil())
+                    expect(fixture.presentDriver.observingScrolls).to(beNil())
+                }
+
+                it("finishes present interaction without reversing") {
+                    let fixture = makeCoreTestTransitionFixture()
+                    let info = FluidGestureInfo(locationLocal: CGPoint(x: 8, y: 16),
+                                                locationGlobal: CGPoint(x: 8, y: 16),
+                                                translation: CGPoint(x: -60, y: 0),
+                                                velocity: CGVector(dx: -2_400, dy: 0),
+                                                direction: .leftMiddle)
+
+                    fixture.presentDriver.beginInteractiveTransition(progress: 0.2, info: info)
+                    fixture.presentDriver.finishInteractiveTransition(isCancelled: false, progress: 0.8, info: info)
+
+                    expect(fixture.presentAnimator.interactionProgress).to(beCloseTo(0.8))
+                    expect(fixture.presentAnimator.currentGestureInfo?.direction.description).to(equal("leftMiddle"))
+                    expect(fixture.sourceDelegate.presentInteractionStates.map { String(describing: $0) }).to(equal(["begin", "end"]))
+                    expect(fixture.destinationDelegate.presentInteractionStates.map { String(describing: $0) }).to(equal(["begin", "end"]))
                     expect(fixture.presentDriver.observingGesture).to(beNil())
                     expect(fixture.presentDriver.observingScrolls).to(beNil())
                 }
@@ -586,6 +634,53 @@ final class UIKitSpec: QuickSpec {
                     expect(animator.layoutContainerView.layer.masksToBounds).to(beTrue())
                     expect(animator.layoutContainerView.layer.cornerRadius).to(beCloseTo(4))
                     expect(animator.layoutContainerView.layer.maskedCorners).to(equal(animator.initialStyle.maskedCorners))
+                }
+
+                it("invalidates animator state and removes transient views") {
+                    let fixture = makeCoreTestTransitionFixture()
+                    let animator = fixture.presentAnimator
+                    let backgroundView = FluidDimmedBackgroundView(color: .black)
+                    let shadowView = FluidShadowView(shadowCornerRadius: 0,
+                                                     shadowRoundingCorners: nil,
+                                                     shadowOpacity: 0,
+                                                     shadowColor: UIColor.black.cgColor,
+                                                     shadowRadius: 0,
+                                                     shadowOffset: .zero,
+                                                     isTransparentBackground: false)
+                    let progressView = FluidProgressView()
+                    let interruptibleView = FluidInterruptibleView()
+
+                    fixture.container.addSubview(backgroundView)
+                    fixture.container.addSubview(shadowView)
+                    fixture.container.addSubview(progressView)
+                    fixture.container.addSubview(interruptibleView)
+
+                    var parameters = animator.parameters!
+                    parameters.backgroundView = backgroundView
+                    parameters.shadowView = shadowView
+                    parameters.progressView = progressView
+                    parameters.interruptibleView = interruptibleView
+                    animator.parameters = parameters
+                    animator.pausedGestureInfo = FluidGestureInfo(direction: .leftMiddle)
+                    animator.currentGestureInfo = FluidGestureInfo(direction: .rightMiddle)
+                    animator.storedFromFrame = CGRect(x: 1, y: 2, width: 3, height: 4)
+                    animator.storedToFrame = CGRect(x: 4, y: 3, width: 2, height: 1)
+                    animator.storedFromStyle = FluidInitialFrameStyle(alpha: 1)
+                    animator.storedToStyle = FluidFinalFrameStyle(alpha: 1)
+
+                    animator.invalidate(willRemoveContainer: true)
+
+                    expect(interruptibleView.superview).to(beNil())
+                    expect(progressView.superview).to(beNil())
+                    expect(backgroundView.superview).to(beNil())
+                    expect(shadowView.superview).to(beNil())
+                    expect(animator.pausedGestureInfo).to(beNil())
+                    expect(animator.currentGestureInfo).to(beNil())
+                    expect(animator.storedFromFrame).to(beNil())
+                    expect(animator.storedToFrame).to(beNil())
+                    expect(animator.storedFromStyle).to(beNil())
+                    expect(animator.storedToStyle).to(beNil())
+                    expect(animator.parameters).to(beNil())
                 }
             }
             describe("FluidShadowLayer") {

--- a/Tests/UIKitSpec.swift
+++ b/Tests/UIKitSpec.swift
@@ -283,6 +283,137 @@ final class UIKitSpec: QuickSpec {
                     expect(controller.fluid.transitionDismissDriver).to(beIdenticalTo(transitionDelegate.dismissDriver))
                 }
             }
+            describe("Core interactive drivers") {
+                it("propagates present interaction lifecycle and stores animator gesture info") {
+                    let fixture = makeCoreTestTransitionFixture()
+                    let info = FluidGestureInfo(locationLocal: CGPoint(x: 12, y: 24),
+                                                locationGlobal: CGPoint(x: 12, y: 24),
+                                                translation: CGPoint(x: -40, y: 0),
+                                                velocity: CGVector(dx: -2_000, dy: 0),
+                                                direction: .leftMiddle)
+
+                    fixture.presentDriver.beginInteractiveTransition(progress: 0.25, info: info)
+
+                    expect(fixture.presentAnimator.interactionProgress).to(beCloseTo(0.25))
+                    expect(fixture.presentAnimator.pausedInteractionProgress).to(beCloseTo(0.25))
+                    expect(fixture.presentAnimator.resizePosition).to(beCloseTo(0))
+                    expect(fixture.sourceDelegate.presentInteractionStates.map { String(describing: $0) }).to(equal(["begin"]))
+                    expect(fixture.destinationDelegate.presentInteractionStates.map { String(describing: $0) }).to(equal(["begin"]))
+
+                    fixture.presentDriver.currentInteractionProgress = 0.65
+                    fixture.presentDriver.previousInteractionProgress = 0.25
+                    fixture.presentDriver.updateInteractiveTransition(progress: 0.65, info: info)
+
+                    expect(fixture.presentAnimator.interactionProgress).to(beCloseTo(0.65))
+                    expect(fixture.presentAnimator.currentGestureInfo?.direction.description).to(equal("leftMiddle"))
+                    expect(fixture.sourceDelegate.presentInteractionStates.map { String(describing: $0) }).to(equal(["begin", "update"]))
+
+                    fixture.presentDriver.finishInteractiveTransition(isCancelled: true, progress: 0.65, info: info)
+
+                    expect(fixture.presentAnimator.currentGestureInfo?.direction.description).to(equal("leftMiddle"))
+                    expect(fixture.sourceDelegate.presentInteractionStates.map { String(describing: $0) }).to(equal(["begin", "update", "cancel"]))
+                    expect(fixture.destinationDelegate.presentInteractionStates.map { String(describing: $0) }).to(equal(["begin", "update", "cancel"]))
+                    expect(fixture.presentDriver.observingGesture).to(beNil())
+                    expect(fixture.presentDriver.observingScrolls).to(beNil())
+                }
+
+                it("evaluates present interaction begin and finish conditions") {
+                    let fixture = makeCoreTestTransitionFixture(style: .slide(direction: .fromRight))
+                    seedGesture(fixture.presentDriver.observingGesture,
+                                averageVector: CGPoint(x: -30, y: 0),
+                                velocity: CGVector(dx: -2_000, dy: 0))
+
+                    expect(fixture.presentDriver.canBeginPresentInteraction()).to(beTrue())
+
+                    fixture.presentDriver.observingGesture.currentVelocity = .zero
+                    expect(fixture.presentDriver.canBeginPresentInteraction()).to(beFalse())
+
+                    seedGesture(fixture.presentDriver.observingGesture,
+                                averageVector: CGPoint(x: 0, y: 30),
+                                velocity: CGVector(dx: -2_000, dy: 0))
+                    expect(fixture.presentDriver.canBeginPresentInteraction()).to(beFalse())
+
+                    let blockedFixture = makeCoreTestTransitionFixture(style: .slide(direction: .fromRight),
+                                                                       allowInteractivePresent: false)
+                    seedGesture(blockedFixture.presentDriver.observingGesture,
+                                averageVector: CGPoint(x: -30, y: 0),
+                                velocity: CGVector(dx: -2_000, dy: 0))
+                    expect(blockedFixture.presentDriver.canBeginPresentInteraction()).to(beFalse())
+
+                    seedGesture(fixture.presentDriver.observingGesture,
+                                averageVector: CGPoint(x: -30, y: 0),
+                                velocity: .zero)
+                    expect(fixture.presentDriver.canFinishPresentInteraction(progress: FluidConst.normalProgressFinishThreshold - 0.01)).to(beFalse())
+                    expect(fixture.presentDriver.canFinishPresentInteraction(progress: FluidConst.normalProgressFinishThreshold)).to(beTrue())
+
+                    seedGesture(fixture.presentDriver.observingGesture,
+                                averageVector: CGPoint(x: -30, y: 0),
+                                velocity: CGVector(dx: -2_000, dy: 0))
+                    expect(fixture.presentDriver.canFinishPresentInteraction(progress: 0.01)).to(beTrue())
+
+                    seedGesture(fixture.presentDriver.observingGesture,
+                                averageVector: CGPoint(x: 30, y: 0),
+                                velocity: CGVector(dx: -2_000, dy: 0))
+                    expect(fixture.presentDriver.canFinishPresentInteraction(progress: 1)).to(beFalse())
+                }
+
+                it("calculates present interaction progress from paused progress and slide axis") {
+                    let fromRight = makeCoreTestTransitionFixture(style: .slide(direction: .fromRight))
+                    fromRight.presentDriver.pausedInterruptibleFractionComplete = 0.2
+                    seedGesture(fromRight.presentDriver.observingGesture,
+                                averageVector: CGPoint(x: -30, y: 0),
+                                initialLocation: CGPoint(x: 200, y: 0),
+                                currentLocation: CGPoint(x: 120, y: 0))
+
+                    expect(fromRight.presentDriver.calculateInteractionProgress()).to(beCloseTo(0.45, within: 0.001))
+
+                    seedGesture(fromRight.presentDriver.observingGesture,
+                                averageVector: CGPoint(x: -30, y: 0),
+                                initialLocation: CGPoint(x: 320, y: 0),
+                                currentLocation: CGPoint(x: -320, y: 0))
+                    expect(fromRight.presentDriver.calculateInteractionProgress()).to(beCloseTo(1, within: 0.001))
+
+                    let fromLeft = makeCoreTestTransitionFixture(style: .slide(direction: .fromLeft))
+                    fromLeft.presentDriver.pausedInterruptibleFractionComplete = 0.1
+                    seedGesture(fromLeft.presentDriver.observingGesture,
+                                averageVector: CGPoint(x: 30, y: 0),
+                                initialLocation: CGPoint(x: 100, y: 0),
+                                currentLocation: CGPoint(x: 260, y: 0))
+
+                    expect(fromLeft.presentDriver.calculateInteractionProgress()).to(beCloseTo(0.6, within: 0.001))
+                }
+
+                it("evaluates dismiss interaction progress and finish conditions") {
+                    let fixture = makeCoreTestTransitionFixture(style: .slide(direction: .fromRight))
+                    seedGesture(fixture.dismissDriver.observingGesture,
+                                averageVector: CGPoint(x: 30, y: 0),
+                                velocity: CGVector(dx: 2_000, dy: 0),
+                                initialLocation: CGPoint(x: 20, y: 0),
+                                currentLocation: CGPoint(x: 180, y: 0))
+
+                    expect(fixture.dismissDriver.canBeginDismissInteraction(isEdgePan: false)).to(beTrue())
+                    expect(fixture.dismissDriver.calculateTransitionProgress(isEdgePan: false)).to(beCloseTo(0.5, within: 0.001))
+                    expect(fixture.dismissDriver.canFinishDismissInteraction(progress: FluidConst.normalProgressFinishThreshold)).to(beTrue())
+
+                    seedGesture(fixture.dismissDriver.observingGesture,
+                                averageVector: CGPoint(x: 30, y: 0),
+                                velocity: CGVector(dx: 2_000, dy: 0))
+                    expect(fixture.dismissDriver.canFinishDismissInteraction(progress: 0.01)).to(beTrue())
+
+                    seedGesture(fixture.dismissDriver.observingGesture,
+                                averageVector: CGPoint(x: -30, y: 0),
+                                velocity: CGVector(dx: 2_000, dy: 0))
+                    expect(fixture.dismissDriver.canBeginDismissInteraction(isEdgePan: false)).to(beFalse())
+                    expect(fixture.dismissDriver.canFinishDismissInteraction(progress: 1)).to(beFalse())
+
+                    let blockedFixture = makeCoreTestTransitionFixture(style: .slide(direction: .fromRight),
+                                                                       allowInteractiveDismiss: false)
+                    seedGesture(blockedFixture.dismissDriver.observingGesture,
+                                averageVector: CGPoint(x: 30, y: 0),
+                                velocity: CGVector(dx: 2_000, dy: 0))
+                    expect(blockedFixture.dismissDriver.canBeginDismissInteraction(isEdgePan: false)).to(beFalse())
+                }
+            }
             describe("FluidLayoutEdgeConstant") {
                 it("calculates edge constants from container size and frame") {
                     let constants = FluidLayoutEdgeConstant(
@@ -690,6 +821,150 @@ private final class CoreTestTransitionRootDelegate: NSObject, FluidTransitionRoo
     func transitionDismissInteractionDidProgress(from destination: FluidDestinationViewController, to source: FluidSourceViewController, with navigation: FluidNavigationController?, on container: UIView?, transitionStyle: FluidTransitionStyle, duration: TimeInterval, easing: FluidAnimatorEasing, state: FluidProgressState, progress: CGFloat, info: FluidGestureInfo) {}
 }
 
-private final class CoreTestTransitionSourceDelegate: NSObject, FluidTransitionSourceViewControllerDelegate {}
+private final class CoreTestTransitionSourceDelegate: NSObject, FluidTransitionSourceViewControllerDelegate {
+    var transitionStyle: FluidTransitionStyle
+    var allowInteractivePresent: Bool
+    var presentInteractionStates: [FluidProgressState] = []
 
-private final class CoreTestTransitionDestinationDelegate: NSObject, FluidTransitionDestinationViewControllerDelegate {}
+    init(transitionStyle: FluidTransitionStyle = .slide(direction: .fromRight),
+         allowInteractivePresent: Bool = true) {
+        self.transitionStyle = transitionStyle
+        self.allowInteractivePresent = allowInteractivePresent
+    }
+
+    func transitionAllowsInteractivePresent(from source: FluidSourceViewController,
+                                            to destination: FluidDestinationViewController,
+                                            with navigation: FluidNavigationController?) -> Bool {
+        return self.allowInteractivePresent
+    }
+
+    func transitionPresentationStyle(from source: FluidSourceViewController,
+                                     to destination: FluidDestinationViewController,
+                                     with navigation: FluidNavigationController?) -> FluidTransitionStyle {
+        return self.transitionStyle
+    }
+
+    func transitionPresentInteractionDidProgress(from source: FluidSourceViewController,
+                                                 to destination: FluidDestinationViewController,
+                                                 with navigation: FluidNavigationController?,
+                                                 on container: UIView?,
+                                                 transitionStyle: FluidTransitionStyle,
+                                                 duration: TimeInterval,
+                                                 easing: FluidAnimatorEasing,
+                                                 state: FluidProgressState,
+                                                 progress: CGFloat,
+                                                 info: FluidGestureInfo) {
+        self.presentInteractionStates.append(state)
+    }
+}
+
+private final class CoreTestTransitionDestinationDelegate: NSObject, FluidTransitionDestinationViewControllerDelegate {
+    var allowInteractiveDismiss: Bool
+    var observedScrollViews: [UIScrollView]?
+    var presentInteractionStates: [FluidProgressState] = []
+
+    init(allowInteractiveDismiss: Bool = true, observedScrollViews: [UIScrollView]? = nil) {
+        self.allowInteractiveDismiss = allowInteractiveDismiss
+        self.observedScrollViews = observedScrollViews
+    }
+
+    func transitionAllowsInteractiveDismiss(from destination: FluidDestinationViewController,
+                                            to source: FluidSourceViewController,
+                                            with navigation: FluidNavigationController?) -> Bool {
+        return self.allowInteractiveDismiss
+    }
+
+    func transitionObservesScrollViews(from destination: FluidDestinationViewController,
+                                       to source: FluidSourceViewController,
+                                       with navigation: FluidNavigationController?) -> [UIScrollView]? {
+        return self.observedScrollViews
+    }
+
+    func transitionPresentInteractionDidProgress(from source: FluidSourceViewController,
+                                                 to destination: FluidDestinationViewController,
+                                                 with navigation: FluidNavigationController?,
+                                                 on container: UIView?,
+                                                 transitionStyle: FluidTransitionStyle,
+                                                 duration: TimeInterval,
+                                                 easing: FluidAnimatorEasing,
+                                                 state: FluidProgressState,
+                                                 progress: CGFloat,
+                                                 info: FluidGestureInfo) {
+        self.presentInteractionStates.append(state)
+    }
+}
+
+private struct CoreTestTransitionFixture {
+    let container: UIView
+    let sourceViewController: CoreTestFluidViewController
+    let destinationViewController: CoreTestFluidViewController
+    let sourceDelegate: CoreTestTransitionSourceDelegate
+    let destinationDelegate: CoreTestTransitionDestinationDelegate
+    let presentAnimator: FluidTransitionViewAnimator
+    let dismissAnimator: FluidTransitionViewAnimator
+    let presentDriver: FluidTransitionPresentDriver
+    let dismissDriver: FluidTransitionDismissDriver
+}
+
+private func makeCoreTestTransitionFixture(style: FluidTransitionStyle = .slide(direction: .fromRight),
+                                           allowInteractivePresent: Bool = true,
+                                           allowInteractiveDismiss: Bool = true,
+                                           observedScrollViews: [UIScrollView]? = nil) -> CoreTestTransitionFixture {
+    let container = UIView(frame: CGRect(x: 0, y: 0, width: 320, height: 480))
+    let sourceViewController = CoreTestFluidViewController()
+    let destinationViewController = CoreTestFluidViewController()
+    let sourceDelegate = CoreTestTransitionSourceDelegate(transitionStyle: style,
+                                                          allowInteractivePresent: allowInteractivePresent)
+    let destinationDelegate = CoreTestTransitionDestinationDelegate(allowInteractiveDismiss: allowInteractiveDismiss,
+                                                                    observedScrollViews: observedScrollViews)
+    let presentAnimator = FluidTransitionViewAnimator()
+    let dismissAnimator = FluidTransitionViewAnimator()
+    let presentDriver = FluidTransitionPresentDriver(presentAnimator)
+    let dismissDriver = FluidTransitionDismissDriver(dismissAnimator)
+
+    sourceViewController.view.frame = container.bounds
+    destinationViewController.view.frame = container.bounds
+    sourceViewController.fluidDelegate = sourceDelegate
+    destinationViewController.fluidDelegate = destinationDelegate
+    container.addSubview(sourceViewController.view)
+
+    try! presentDriver.configureParameters(driverType: .present,
+                                           animationType: .present,
+                                           context: nil,
+                                           container: container,
+                                           source: sourceViewController,
+                                           destination: destinationViewController,
+                                           initialContainerSize: container.bounds.size,
+                                           finalContainerSize: container.bounds.size,
+                                           shouldInsertSubview: true)
+    try! dismissDriver.configureParameters(driverType: .dismiss,
+                                           animationType: .dismiss,
+                                           context: nil,
+                                           container: container,
+                                           source: sourceViewController,
+                                           destination: destinationViewController,
+                                           initialContainerSize: container.bounds.size,
+                                           finalContainerSize: container.bounds.size,
+                                           shouldInsertSubview: true)
+
+    return CoreTestTransitionFixture(container: container,
+                                     sourceViewController: sourceViewController,
+                                     destinationViewController: destinationViewController,
+                                     sourceDelegate: sourceDelegate,
+                                     destinationDelegate: destinationDelegate,
+                                     presentAnimator: presentAnimator,
+                                     dismissAnimator: dismissAnimator,
+                                     presentDriver: presentDriver,
+                                     dismissDriver: dismissDriver)
+}
+
+private func seedGesture(_ observer: FluidTransitionGestureObserver,
+                         averageVector: CGPoint,
+                         velocity: CGVector = .zero,
+                         initialLocation: CGPoint = .zero,
+                         currentLocation: CGPoint = .zero) {
+    observer.initialLocation = initialLocation
+    observer.currentLocation = currentLocation
+    observer.currentVelocity = velocity
+    observer.translationHistory = [averageVector, .zero]
+}

--- a/Tests/UIKitSpec.swift
+++ b/Tests/UIKitSpec.swift
@@ -23,6 +23,8 @@ final class UIKitSpec: QuickSpec {
         }
     }
 
+    class TestInteractiveView: UIView, FluidInteractiveView {}
+
     class TestNavigationController: UINavigationController {
         var name: String?
         init(rootViewController: UIViewController, name: String) {
@@ -57,6 +59,44 @@ final class UIKitSpec: QuickSpec {
         }
         required init?(coder aDecoder: NSCoder) {
             super.init(coder: aDecoder)
+        }
+    }
+
+    class TestShadowLayerCoder: NSCoder {
+        var floats: [String: Float] = [:]
+        var bools: [String: Bool] = [:]
+
+        override var allowsKeyedCoding: Bool { return true }
+
+        override func encode(_ value: Float, forKey key: String) {
+            floats[key] = value
+        }
+
+        override func encode(_ value: Bool, forKey key: String) {
+            bools[key] = value
+        }
+
+        override func encode(_ objv: Any?, forKey key: String) {}
+        override func encode(_ value: Double, forKey key: String) {}
+        override func encode(_ value: Int, forKey key: String) {}
+        override func encode(_ value: Int32, forKey key: String) {}
+        override func encode(_ value: Int64, forKey key: String) {}
+        override func encodeBytes(_ bytesp: UnsafePointer<UInt8>?, length lenv: Int, forKey key: String) {}
+
+        override func decodeFloat(forKey key: String) -> Float {
+            return floats[key] ?? 0
+        }
+
+        override func decodeBool(forKey key: String) -> Bool {
+            return bools[key] ?? false
+        }
+
+        override func decodeObject(forKey key: String) -> Any? {
+            return nil
+        }
+
+        override func containsValue(forKey key: String) -> Bool {
+            return floats[key] != nil || bools[key] != nil
         }
     }
 
@@ -792,6 +832,64 @@ final class UIKitSpec: QuickSpec {
                     expect(layer.mask as? CAShapeLayer).notTo(beNil())
                     expect(FluidShadowLayer.needsDisplay(forKey: "shadowCornerRadius")).to(beTrue())
                     expect(FluidShadowLayer.needsDisplay(forKey: "isTransparentBackground")).to(beTrue())
+                }
+
+                it("preserves shadow state when copied and encoded") {
+                    let layer = FluidShadowLayer(frame: CGRect(x: 1, y: 2, width: 30, height: 40))
+                    layer.castShadow(frame: CGRect(x: 0, y: 0, width: 50, height: 60),
+                                     shadowCornerRadius: 9,
+                                     shadowRoundingCorners: [.topLeft, .bottomRight],
+                                     shadowColor: UIColor.green.cgColor,
+                                     shadowOpacity: 0.45,
+                                     shadowRadius: 6,
+                                     shadowOffset: CGSize(width: 3, height: 4),
+                                     isTransparentBackground: true)
+
+                    layer.castShadow(frame: CGRect(x: 0, y: 0, width: 50, height: 60))
+
+                    expect(layer.shadowCornerRadius).to(beCloseTo(9))
+                    expect(layer.shadowRoundingCorners).to(equal([.topLeft, .bottomRight]))
+                    expect(CGFloat(layer.shadowOpacity)).to(beCloseTo(0.45, within: 0.001))
+                    expect(layer.shadowRadius).to(beCloseTo(6))
+                    expect(layer.shadowOffset).to(equal(CGSize(width: 3, height: 4)))
+                    expect(layer.isTransparentBackground).to(beTrue())
+
+                    let copied = FluidShadowLayer(layer: layer)
+                    expect(copied.shadowCornerRadius).to(beCloseTo(layer.shadowCornerRadius))
+                    expect(copied.shadowRoundingCorners).to(equal(layer.shadowRoundingCorners))
+                    expect(copied.isTransparentBackground).to(equal(layer.isTransparentBackground))
+
+                    let coder = TestShadowLayerCoder()
+                    layer.encode(with: coder)
+
+                    let decoded = FluidShadowLayer(coder: coder)
+
+                    expect(decoded?.shadowCornerRadius).to(beCloseTo(layer.shadowCornerRadius))
+                    expect(decoded?.isTransparentBackground).to(equal(layer.isTransparentBackground))
+                    expect(FluidShadowLayer.needsDisplay(forKey: "shadowOpacity")).to(beFalse())
+                }
+            }
+            describe("FluidInteractiveView") {
+                it("expands, restores, and resets transforms") {
+                    let view = TestInteractiveView(frame: CGRect(x: 0, y: 0, width: 40, height: 40))
+
+                    expect(view.expandScale).to(beCloseTo(1.05))
+                    expect(view.restoreScale).to(beCloseTo(1.0))
+
+                    view.expand()
+
+                    expect(view.transform.a).to(beCloseTo(view.expandScale, within: 0.001))
+                    expect(view.transform.d).to(beCloseTo(view.expandScale, within: 0.001))
+
+                    view.restore()
+
+                    expect(view.transform.a).to(beCloseTo(view.restoreScale, within: 0.001))
+                    expect(view.transform.d).to(beCloseTo(view.restoreScale, within: 0.001))
+
+                    view.transform = CGAffineTransform(scaleX: 0.5, y: 0.5)
+                    view.reset()
+
+                    expect(view.transform).to(equal(.identity))
                 }
             }
             describe("FluidCornerMaskLayer") {

--- a/Tests/UIKitSpec.swift
+++ b/Tests/UIKitSpec.swift
@@ -1455,6 +1455,105 @@ final class UIKitSpec: QuickSpec {
                     expect(shadowView.layer.shadowPath).notTo(beNil())
                     expect((shadowView.layer.mask as? CAShapeLayer)?.path).notTo(beNil())
                 }
+
+                it("updates fluid dismiss transform and shadow feedback") {
+                    let fixture = makeCoreTestTransitionFixture(style: .fluid(behavior: .all),
+                                                                easing: .linear)
+                    let animator = fixture.dismissAnimator
+                    let backgroundView = FluidDimmedBackgroundView(color: .black)
+                    let shadowView = FluidShadowView(shadowCornerRadius: 0,
+                                                     shadowRoundingCorners: nil,
+                                                     shadowOpacity: 0,
+                                                     shadowColor: UIColor.black.cgColor,
+                                                     shadowRadius: 0,
+                                                     shadowOffset: .zero,
+                                                     isTransparentBackground: false)
+
+                    fixture.container.insertSubview(backgroundView, belowSubview: animator.layoutContainerView)
+                    fixture.container.addSubview(shadowView)
+                    animator.parameters.backgroundView = backgroundView
+                    animator.parameters.shadowView = shadowView
+                    shadowView.layer.mask = CAShapeLayer()
+
+                    animator.beginInteraction(progress: 0, position: 0, info: FluidGestureInfo(translation: .zero))
+                    defer {
+                        animator.animationTimer?.stop()
+                        animator.animationTimer = nil
+                    }
+
+                    var fromStyle = FluidFinalFrameStyle(cornerRadius: 20,
+                                                         cornerStyle: .all,
+                                                         shadowColor: UIColor.red.cgColor,
+                                                         shadowOpacity: 0.8,
+                                                         shadowRadius: 12,
+                                                         shadowOffset: CGSize(width: 4, height: 2))
+                    fromStyle.isTransparentBackground = true
+                    let toStyle = FluidInitialFrameStyle(cornerRadius: 4,
+                                                         shadowColor: UIColor.blue.cgColor,
+                                                         shadowOpacity: 0.2,
+                                                         shadowRadius: 2,
+                                                         shadowOffset: CGSize(width: -2, height: 6))
+
+                    animator.storedFromStyle = fromStyle
+                    animator.storedToStyle = toStyle
+                    animator.updateInteraction(progress: 0.5,
+                                               position: 0,
+                                               info: FluidGestureInfo(translation: CGPoint(x: 80, y: 40)))
+                    animator.animationTimerDidUpdate()
+
+                    expect(animator.layoutContainerView.transform.a).to(beLessThan(1))
+                    expect(animator.layoutContainerView.transform.d).to(beLessThan(1))
+                    expect(animator.layoutContainerView.transform.tx).to(beGreaterThan(0))
+                    expect(animator.layoutContainerView.transform.ty).to(beGreaterThan(0))
+                    expect(animator.layoutContainerView.layer.cornerRadius).to(beCloseTo(13.6, within: 0.001))
+                    expect(animator.backgroundView?.visibility).to(beCloseTo(0.75, within: 0.001))
+                    expect(shadowView.layer.frame).to(equal(animator.layoutContainerView.layer.frame))
+                    expect(CGFloat(shadowView.layer.shadowOpacity)).to(beCloseTo(0.65, within: 0.001))
+                    expect(shadowView.layer.shadowRadius).to(beCloseTo(9.5, within: 0.001))
+                    expect(shadowView.layer.shadowPath).notTo(beNil())
+                    expect((shadowView.layer.mask as? CAShapeLayer)?.path).notTo(beNil())
+                }
+
+                it("resizes drawer frames from interaction position") {
+                    let resizeDelegate = CoreTestResizableDelegate()
+                    let finalDimension = FluidFinalFrameDimension(for: FluidTransitionStyle.drawer(position: .bottom),
+                                                                  portraitContainerSize: CGSize(width: 320, height: 480),
+                                                                  landscapeContainerSize: CGSize(width: 480, height: 320),
+                                                                  portraitContentSize: CGSize(width: 320, height: 240),
+                                                                  landscapeContentSize: CGSize(width: 480, height: 160),
+                                                                  portraitContentTransform: CGAffineTransform.identity,
+                                                                  landscapeContentTransform: CGAffineTransform.identity)
+                    let fixture = makeCoreTestTransitionFixture(style: .drawer(position: .bottom),
+                                                                resizableDelegate: resizeDelegate,
+                                                                finalDimension: finalDimension)
+                    let animator = fixture.dismissAnimator
+                    let shadowView = FluidShadowView(shadowCornerRadius: 8,
+                                                     shadowRoundingCorners: nil,
+                                                     shadowOpacity: 0.7,
+                                                     shadowColor: UIColor.black.cgColor,
+                                                     shadowRadius: 6,
+                                                     shadowOffset: CGSize(width: 0, height: 4),
+                                                     isTransparentBackground: false)
+
+                    fixture.container.addSubview(shadowView)
+                    animator.parameters.shadowView = shadowView
+
+                    animator.interactionDidStart(progress: 0, position: 0, info: FluidGestureInfo())
+                    defer {
+                        animator.animationTimer?.stop()
+                        animator.animationTimer = nil
+                    }
+
+                    animator.resizePosition = 0.5
+                    animator.animationTimerDidUpdate()
+
+                    let expectedTop = animator.baseConstantForResizing - animator.constantRangeForResizing * 0.5
+
+                    expect(animator.shouldPerformResizing).to(beTrue())
+                    expect(animator.layout.top.constant).to(beCloseTo(expectedTop, within: 0.001))
+                    expect(animator.layoutContainerView.layer.cornerRadius).to(beCloseTo(animator.storedFromStyle.cornerRadius, within: 0.001))
+                    expect(shadowView.layer.shadowPath).notTo(beNil())
+                }
             }
             describe("Transition scroll observer") {
                 it("observes, locks, and restores scroll state") {
@@ -2204,6 +2303,7 @@ private final class CoreTestTransitionSourceDelegate: NSObject, FluidTransitionS
     var transitionStyle: FluidTransitionStyle
     var allowInteractivePresent: Bool
     var finalDimension: FluidFinalFrameDimension?
+    var easing: FluidAnimatorEasing?
     var presentAnimationStates: [FluidProgressState] = []
     var dismissAnimationStates: [FluidProgressState] = []
     var presentInteractionStates: [FluidProgressState] = []
@@ -2211,10 +2311,12 @@ private final class CoreTestTransitionSourceDelegate: NSObject, FluidTransitionS
 
     init(transitionStyle: FluidTransitionStyle = .slide(direction: .fromRight),
          allowInteractivePresent: Bool = true,
-         finalDimension: FluidFinalFrameDimension? = nil) {
+         finalDimension: FluidFinalFrameDimension? = nil,
+         easing: FluidAnimatorEasing? = nil) {
         self.transitionStyle = transitionStyle
         self.allowInteractivePresent = allowInteractivePresent
         self.finalDimension = finalDimension
+        self.easing = easing
     }
 
     func transitionAllowsInteractivePresent(from source: FluidSourceViewController,
@@ -2233,6 +2335,18 @@ private final class CoreTestTransitionSourceDelegate: NSObject, FluidTransitionS
                                                   to destination: FluidDestinationViewController,
                                                   with navigation: FluidNavigationController?) -> FluidFinalFrameDimension? {
         return self.finalDimension
+    }
+
+    func transitionPresentEasing(from source: FluidSourceViewController,
+                                 to destination: FluidDestinationViewController,
+                                 with navigation: FluidNavigationController?) -> FluidAnimatorEasing? {
+        return self.easing
+    }
+
+    func transitionDismissEasing(from destination: FluidDestinationViewController,
+                                 to source: FluidSourceViewController,
+                                 with navigation: FluidNavigationController?) -> FluidAnimatorEasing? {
+        return self.easing
     }
 
     func transitionPresentAnimationDidProgress(from source: FluidSourceViewController,
@@ -2401,13 +2515,15 @@ private func makeCoreTestTransitionFixture(style: FluidTransitionStyle = .slide(
                                            allowInteractiveDismiss: Bool = true,
                                            observedScrollViews: [UIScrollView]? = nil,
                                            resizableDelegate: FluidResizableTransitionDelegate? = nil,
-                                           finalDimension: FluidFinalFrameDimension? = nil) -> CoreTestTransitionFixture {
+                                           finalDimension: FluidFinalFrameDimension? = nil,
+                                           easing: FluidAnimatorEasing? = nil) -> CoreTestTransitionFixture {
     let container = UIView(frame: CGRect(x: 0, y: 0, width: 320, height: 480))
     let sourceViewController = CoreTestFluidViewController()
     let destinationViewController = CoreTestFluidViewController()
     let sourceDelegate = CoreTestTransitionSourceDelegate(transitionStyle: style,
                                                           allowInteractivePresent: allowInteractivePresent,
-                                                          finalDimension: finalDimension)
+                                                          finalDimension: finalDimension,
+                                                          easing: easing)
     let destinationDelegate = CoreTestTransitionDestinationDelegate(allowInteractiveDismiss: allowInteractiveDismiss,
                                                                     observedScrollViews: observedScrollViews)
     let presentAnimator = FluidTransitionViewAnimator()
@@ -2430,6 +2546,7 @@ private func makeCoreTestTransitionFixture(style: FluidTransitionStyle = .slide(
                                            destination: destinationViewController,
                                            initialContainerSize: container.bounds.size,
                                            finalContainerSize: container.bounds.size,
+                                           easing: easing,
                                            shouldInsertSubview: true)
     try! dismissDriver.configureParameters(driverType: .dismiss,
                                            animationType: .dismiss,
@@ -2439,6 +2556,7 @@ private func makeCoreTestTransitionFixture(style: FluidTransitionStyle = .slide(
                                            destination: destinationViewController,
                                            initialContainerSize: container.bounds.size,
                                            finalContainerSize: container.bounds.size,
+                                           easing: easing,
                                            shouldInsertSubview: true)
 
     return CoreTestTransitionFixture(container: container,

--- a/Tests/UIKitSpec.swift
+++ b/Tests/UIKitSpec.swift
@@ -529,6 +529,81 @@ final class UIKitSpec: QuickSpec {
                     expect(blockedFixture.dismissDriver.canBeginDismissInteraction(isEdgePan: false)).to(beFalse())
                 }
             }
+            describe("Core animated drivers") {
+                it("configures present animators and completes a successful transition") {
+                    let fixture = makeCoreTestTransitionFixture(style: .slide(direction: .fromBottom))
+                    let context = CoreTestTransitionContext(container: fixture.container,
+                                                            from: fixture.sourceViewController,
+                                                            to: fixture.destinationViewController)
+
+                    let firstAnimator = fixture.presentDriver.configureInterruptibleAnimator(using: context)
+                    let secondAnimator = fixture.presentDriver.configureInterruptibleAnimator(using: context)
+
+                    expect((firstAnimator as AnyObject) === (secondAnimator as AnyObject)).to(beTrue())
+                    expect(fixture.presentDriver.interruptibleAnimator).notTo(beNil())
+                    expect(fixture.presentAnimator.interruptibleAnimator).notTo(beNil())
+                    expect(fixture.presentAnimator.progressAnimator).notTo(beNil())
+                    expect(fixture.presentAnimator.activeDuration).to(beCloseTo(fixture.presentDriver.presentDuration, within: 0.001))
+                    expect(fixture.sourceDelegate.presentAnimationStates.map { String(describing: $0) }).to(equal(["begin"]))
+                    expect(fixture.destinationDelegate.presentAnimationStates.map { String(describing: $0) }).to(equal(["begin"]))
+
+                    fixture.presentAnimator.progressAnimatorDidUpdate(progress: 0.4)
+                    fixture.presentAnimator.progressAnimator?._animatorState = .finished
+
+                    expect(fixture.sourceDelegate.presentAnimationStates.map { String(describing: $0) }).to(equal(["begin", "update"]))
+                    expect(fixture.destinationDelegate.presentAnimationStates.map { String(describing: $0) }).to(equal(["begin", "update"]))
+                    expect(context.completedTransitions).to(equal([true]))
+                }
+
+                it("configures dismiss animators from interaction progress and completes cancellation") {
+                    let fixture = makeCoreTestTransitionFixture(style: .slide(direction: .fromRight))
+                    let context = CoreTestTransitionContext(container: fixture.container,
+                                                            from: fixture.destinationViewController,
+                                                            to: fixture.sourceViewController,
+                                                            transitionWasCancelled: true)
+                    fixture.dismissDriver.currentInteractionProgress = 0.4
+                    fixture.dismissDriver.isInteractionCancelled = true
+
+                    _ = fixture.dismissDriver.configureInterruptibleAnimator(using: context)
+
+                    expect(fixture.dismissDriver.interruptibleAnimator).notTo(beNil())
+                    expect(fixture.dismissAnimator.progressAnimator).notTo(beNil())
+                    expect(fixture.dismissAnimator.activeDuration).to(beCloseTo(fixture.dismissDriver.dismissDuration * 0.6, within: 0.001))
+                    expect(fixture.dismissAnimator.activeEasing).to(equal(FluidAnimatorEasing.linear))
+                    expect(fixture.sourceDelegate.dismissAnimationStates.map { String(describing: $0) }).to(equal(["begin"]))
+                    expect(fixture.destinationDelegate.dismissAnimationStates.map { String(describing: $0) }).to(equal(["begin"]))
+
+                    fixture.dismissAnimator.progressAnimatorDidUpdate(progress: 0.25)
+                    fixture.dismissAnimator.progressAnimator?._animatorState = .finished
+
+                    expect(fixture.sourceDelegate.dismissAnimationStates.map { String(describing: $0) }).to(equal(["begin", "update"]))
+                    expect(fixture.destinationDelegate.dismissAnimationStates.map { String(describing: $0) }).to(equal(["begin", "update"]))
+                    expect(context.completedTransitions).to(equal([false]))
+                }
+
+                it("configures reverse and rotate animations from current driver parameters") {
+                    let reverseFixture = makeCoreTestTransitionFixture(style: .slide(direction: .fromBottom))
+                    reverseFixture.presentDriver.currentInteractionProgress = 0.35
+
+                    reverseFixture.presentDriver.configureAndRunReverseTransitionAnimation()
+
+                    expect(reverseFixture.presentAnimator.progressAnimator).notTo(beNil())
+                    expect(reverseFixture.presentAnimator.progressAnimator?.duration).to(beCloseTo(FluidConst.fluidInteractionReverseDuration, within: 0.001))
+
+                    let rotateFixture = makeCoreTestTransitionFixture(style: .slide(direction: .fromBottom))
+                    rotateFixture.dismissDriver.configureAndRunRotateAnimation(from: CGSize(width: 320, height: 480),
+                                                                               to: CGSize(width: 480, height: 320),
+                                                                               duration: 0.12)
+
+                    expect(rotateFixture.dismissDriver.parameters.animationType).to(equal(.rotate))
+                    expect(rotateFixture.dismissAnimator.progressAnimator?.duration).to(beCloseTo(0.12, within: 0.001))
+
+                    rotateFixture.dismissAnimator.progressAnimator?._animatorState = .finished
+
+                    expect(rotateFixture.dismissDriver.parameters.animationType).to(equal(.dismiss))
+                    expect(rotateFixture.dismissDriver.observingGesture).notTo(beNil())
+                }
+            }
             describe("Core animator helpers") {
                 it("converts delayed transition progress into animator progress") {
                     let fixture = makeCoreTestTransitionFixture()
@@ -1806,6 +1881,88 @@ private final class CoreTestFluidViewController: UIViewController, Fluidable {}
 
 private final class CoreTestFluidNavigationController: UINavigationController, Fluidable {}
 
+private final class CoreTestTransitionContext: NSObject, UIViewControllerContextTransitioning {
+    let containerView: UIView
+    var isAnimated: Bool
+    var isInteractive: Bool
+    var transitionWasCancelled: Bool
+    var presentationStyle: UIModalPresentationStyle
+    var completedTransitions: [Bool] = []
+    var updatedPercentCompletes: [CGFloat] = []
+    var didFinishInteractiveTransition = false
+    var didCancelInteractiveTransition = false
+    var didPauseInteractiveTransition = false
+
+    private let fromViewController: UIViewController
+    private let toViewController: UIViewController
+
+    init(container: UIView,
+         from fromViewController: UIViewController,
+         to toViewController: UIViewController,
+         transitionWasCancelled: Bool = false,
+         isAnimated: Bool = true,
+         isInteractive: Bool = false,
+         presentationStyle: UIModalPresentationStyle = .custom) {
+        self.containerView = container
+        self.fromViewController = fromViewController
+        self.toViewController = toViewController
+        self.transitionWasCancelled = transitionWasCancelled
+        self.isAnimated = isAnimated
+        self.isInteractive = isInteractive
+        self.presentationStyle = presentationStyle
+        super.init()
+    }
+
+    func updateInteractiveTransition(_ percentComplete: CGFloat) {
+        self.updatedPercentCompletes.append(percentComplete)
+    }
+
+    func finishInteractiveTransition() {
+        self.didFinishInteractiveTransition = true
+    }
+
+    func cancelInteractiveTransition() {
+        self.didCancelInteractiveTransition = true
+        self.transitionWasCancelled = true
+    }
+
+    func pauseInteractiveTransition() {
+        self.didPauseInteractiveTransition = true
+    }
+
+    func completeTransition(_ didComplete: Bool) {
+        self.completedTransitions.append(didComplete)
+    }
+
+    func viewController(forKey key: UITransitionContextViewControllerKey) -> UIViewController? {
+        switch key {
+        case .from: return self.fromViewController
+        case .to:   return self.toViewController
+        default:    return nil
+        }
+    }
+
+    func view(forKey key: UITransitionContextViewKey) -> UIView? {
+        switch key {
+        case .from: return self.fromViewController.view
+        case .to:   return self.toViewController.view
+        default:    return nil
+        }
+    }
+
+    var targetTransform: CGAffineTransform {
+        return .identity
+    }
+
+    func initialFrame(for viewController: UIViewController) -> CGRect {
+        return viewController === self.fromViewController ? self.containerView.bounds : .zero
+    }
+
+    func finalFrame(for viewController: UIViewController) -> CGRect {
+        return viewController === self.toViewController ? self.containerView.bounds : .zero
+    }
+}
+
 private final class CoreTestNavigationRootDelegate: NSObject, FluidNavigationRootNavigationControllerDelegate {
     func navigationPresentAnimationDidProgress(from source: FluidSourceViewController, to destination: FluidDestinationViewController, with navigation: FluidNavigationController?, on container: UIView?, navigationStyle: FluidNavigationStyle, duration: TimeInterval, easing: FluidAnimatorEasing, state: FluidProgressState, progress: CGFloat) {}
     func navigationDismissAnimationDidProgress(from destination: FluidDestinationViewController, to source: FluidSourceViewController, with navigation: FluidNavigationController?, on container: UIView?, navigationStyle: FluidNavigationStyle, duration: TimeInterval, easing: FluidAnimatorEasing, state: FluidProgressState, progress: CGFloat) {}
@@ -1913,6 +2070,8 @@ private final class CoreTestTransitionRootDelegate: NSObject, FluidTransitionRoo
 private final class CoreTestTransitionSourceDelegate: NSObject, FluidTransitionSourceViewControllerDelegate {
     var transitionStyle: FluidTransitionStyle
     var allowInteractivePresent: Bool
+    var presentAnimationStates: [FluidProgressState] = []
+    var dismissAnimationStates: [FluidProgressState] = []
     var presentInteractionStates: [FluidProgressState] = []
 
     init(transitionStyle: FluidTransitionStyle = .slide(direction: .fromRight),
@@ -1933,6 +2092,30 @@ private final class CoreTestTransitionSourceDelegate: NSObject, FluidTransitionS
         return self.transitionStyle
     }
 
+    func transitionPresentAnimationDidProgress(from source: FluidSourceViewController,
+                                               to destination: FluidDestinationViewController,
+                                               with navigation: FluidNavigationController?,
+                                               on container: UIView?,
+                                               transitionStyle: FluidTransitionStyle,
+                                               duration: TimeInterval,
+                                               easing: FluidAnimatorEasing,
+                                               state: FluidProgressState,
+                                               progress: CGFloat) {
+        self.presentAnimationStates.append(state)
+    }
+
+    func transitionDismissAnimationDidProgress(from destination: FluidDestinationViewController,
+                                               to source: FluidSourceViewController,
+                                               with navigation: FluidNavigationController?,
+                                               on container: UIView?,
+                                               transitionStyle: FluidTransitionStyle,
+                                               duration: TimeInterval,
+                                               easing: FluidAnimatorEasing,
+                                               state: FluidProgressState,
+                                               progress: CGFloat) {
+        self.dismissAnimationStates.append(state)
+    }
+
     func transitionPresentInteractionDidProgress(from source: FluidSourceViewController,
                                                  to destination: FluidDestinationViewController,
                                                  with navigation: FluidNavigationController?,
@@ -1950,6 +2133,8 @@ private final class CoreTestTransitionSourceDelegate: NSObject, FluidTransitionS
 private final class CoreTestTransitionDestinationDelegate: NSObject, FluidTransitionDestinationViewControllerDelegate {
     var allowInteractiveDismiss: Bool
     var observedScrollViews: [UIScrollView]?
+    var presentAnimationStates: [FluidProgressState] = []
+    var dismissAnimationStates: [FluidProgressState] = []
     var presentInteractionStates: [FluidProgressState] = []
 
     init(allowInteractiveDismiss: Bool = true, observedScrollViews: [UIScrollView]? = nil) {
@@ -1967,6 +2152,30 @@ private final class CoreTestTransitionDestinationDelegate: NSObject, FluidTransi
                                        to source: FluidSourceViewController,
                                        with navigation: FluidNavigationController?) -> [UIScrollView]? {
         return self.observedScrollViews
+    }
+
+    func transitionPresentAnimationDidProgress(from source: FluidSourceViewController,
+                                               to destination: FluidDestinationViewController,
+                                               with navigation: FluidNavigationController?,
+                                               on container: UIView?,
+                                               transitionStyle: FluidTransitionStyle,
+                                               duration: TimeInterval,
+                                               easing: FluidAnimatorEasing,
+                                               state: FluidProgressState,
+                                               progress: CGFloat) {
+        self.presentAnimationStates.append(state)
+    }
+
+    func transitionDismissAnimationDidProgress(from destination: FluidDestinationViewController,
+                                               to source: FluidSourceViewController,
+                                               with navigation: FluidNavigationController?,
+                                               on container: UIView?,
+                                               transitionStyle: FluidTransitionStyle,
+                                               duration: TimeInterval,
+                                               easing: FluidAnimatorEasing,
+                                               state: FluidProgressState,
+                                               progress: CGFloat) {
+        self.dismissAnimationStates.append(state)
     }
 
     func transitionPresentInteractionDidProgress(from source: FluidSourceViewController,

--- a/Tests/UIKitSpec.swift
+++ b/Tests/UIKitSpec.swift
@@ -25,6 +25,76 @@ final class UIKitSpec: QuickSpec {
 
     class TestInteractiveView: UIView, FluidInteractiveView {}
 
+    class TrackingScrollView: UIScrollView {
+        var isTrackingOverride: Bool = false
+
+        override var isTracking: Bool {
+            return self.isTrackingOverride
+        }
+    }
+
+    class StubTapGestureRecognizer: UITapGestureRecognizer {
+        var locationValue: CGPoint = .zero
+
+        override func location(in view: UIView?) -> CGPoint {
+            return self.locationValue
+        }
+    }
+
+    class StubPanGestureRecognizer: UIPanGestureRecognizer {
+        var locationValue: CGPoint = .zero
+        var translationValue: CGPoint = .zero
+        var velocityValue: CGPoint = .zero
+
+        override func location(in view: UIView?) -> CGPoint {
+            return self.locationValue
+        }
+
+        override func translation(in view: UIView?) -> CGPoint {
+            return self.translationValue
+        }
+
+        override func velocity(in view: UIView?) -> CGPoint {
+            return self.velocityValue
+        }
+    }
+
+    class StubScreenEdgePanGestureRecognizer: UIScreenEdgePanGestureRecognizer {
+        var locationValue: CGPoint = .zero
+        var translationValue: CGPoint = .zero
+        var velocityValue: CGPoint = .zero
+
+        override func location(in view: UIView?) -> CGPoint {
+            return self.locationValue
+        }
+
+        override func translation(in view: UIView?) -> CGPoint {
+            return self.translationValue
+        }
+
+        override func velocity(in view: UIView?) -> CGPoint {
+            return self.velocityValue
+        }
+    }
+
+    class TestGestureDelegate: NSObject, FluidGestureDelegate {
+        var tapUpdateCount: Int = 0
+        var panUpdateCount: Int = 0
+        var edgePanUpdateCount: Int = 0
+
+        func tapGestureDidUpdate(gesture: UITapGestureRecognizer) {
+            self.tapUpdateCount += 1
+        }
+
+        func panGestureDidUpdate(gesture: UIPanGestureRecognizer) {
+            self.panUpdateCount += 1
+        }
+
+        func edgePanGestureDidUpdate(gesture: UIScreenEdgePanGestureRecognizer) {
+            self.edgePanUpdateCount += 1
+        }
+    }
+
     class TestBlurredBackgroundView: FluidBlurredBackgroundView {
         var blurRadiusValues: [CGFloat] = []
         var colorTintValues: [UIColor?] = []
@@ -1607,6 +1677,245 @@ final class UIKitSpec: QuickSpec {
 
                     expect(observer.panGestureRecognizer).to(beNil())
                     expect(observer.offsetObservation).to(beNil())
+                }
+
+                it("evaluates dismiss and resize boundaries while scroll view is tracking") {
+                    let scrollView = TrackingScrollView(frame: CGRect(x: 0, y: 0, width: 120, height: 120))
+                    scrollView.contentSize = CGSize(width: 360, height: 360)
+                    scrollView.isTrackingOverride = true
+
+                    func makeObserver(style: FluidTransitionStyle) -> FluidTransitionScrollObserver {
+                        let fixture = makeCoreTestTransitionFixture(style: style, easing: .linear)
+                        let observer = FluidTransitionScrollObserver(view: scrollView)
+                        observer.registerParameters(parameters: fixture.dismissDriver.parameters)
+                        return observer
+                    }
+
+                    let bottomSlide = makeObserver(style: .slide(direction: .fromBottom))
+                    bottomSlide.gestureDirection = .bottomCenter
+                    scrollView.contentOffset = .zero
+                    expect(bottomSlide.isDismissAllowed()).to(beTrue())
+                    scrollView.contentOffset = CGPoint(x: 0, y: 24)
+                    expect(bottomSlide.isDismissAllowed()).to(beFalse())
+                    bottomSlide.gestureDirection = .topCenter
+                    scrollView.contentOffset = .zero
+                    expect(bottomSlide.isDismissAllowed()).to(beFalse())
+
+                    let topSlide = makeObserver(style: .slide(direction: .fromTop))
+                    topSlide.gestureDirection = .topCenter
+                    scrollView.contentOffset = CGPoint(x: 0, y: scrollView.maxScrollableY)
+                    expect(topSlide.isDismissAllowed()).to(beTrue())
+
+                    let leftSlide = makeObserver(style: .slide(direction: .fromLeft))
+                    leftSlide.gestureDirection = .leftMiddle
+                    scrollView.contentOffset = CGPoint(x: scrollView.maxScrollableX, y: 0)
+                    expect(leftSlide.isDismissAllowed()).to(beTrue())
+
+                    let rightSlide = makeObserver(style: .slide(direction: .fromRight))
+                    rightSlide.gestureDirection = .rightMiddle
+                    scrollView.contentOffset = .zero
+                    expect(rightSlide.isDismissAllowed()).to(beTrue())
+
+                    let fluid = makeObserver(style: .fluid(behavior: .all))
+                    fluid.gestureDirection = .bottomCenter
+                    scrollView.contentOffset = .zero
+                    expect(fluid.isDismissAllowed()).to(beTrue())
+                    fluid.gestureDirection = .leftMiddle
+                    expect(fluid.isDismissAllowed()).to(beTrue())
+
+                    let scale = makeObserver(style: .scale)
+                    scale.gestureDirection = .bottomCenter
+                    expect(scale.isDismissAllowed()).to(beTrue())
+                    scale.gestureDirection = .none
+                    expect(scale.isDismissAllowed()).to(beFalse())
+
+                    let drawer = makeObserver(style: .drawer(position: .bottom))
+                    drawer.gestureDirection = .bottomCenter
+                    scrollView.contentOffset = .zero
+                    expect(drawer.isDismissAllowed()).to(beTrue())
+                    expect(drawer.isResizeAllowed()).to(beTrue())
+                    scrollView.contentOffset = CGPoint(x: 0, y: 24)
+                    expect(drawer.isResizeAllowed()).to(beFalse())
+                    scrollView.contentSize = CGSize(width: 120, height: 80)
+                    expect(drawer.isResizeAllowed()).to(beTrue())
+
+                    scrollView.contentSize = CGSize(width: 360, height: 360)
+                    scrollView.isTrackingOverride = false
+                    expect(bottomSlide.isDismissAllowed()).to(beTrue())
+                    expect(drawer.isResizeAllowed()).to(beTrue())
+                    scrollView.isTrackingOverride = true
+                    scrollView.isScrollEnabled = false
+                    expect(bottomSlide.isDismissAllowed()).to(beTrue())
+                    expect(drawer.isResizeAllowed()).to(beTrue())
+                }
+
+                it("locks offsets for fluid and drawer styles without changing drawer interaction") {
+                    let scrollView = UIScrollView(frame: CGRect(x: 0, y: 0, width: 120, height: 120))
+                    scrollView.contentSize = CGSize(width: 360, height: 360)
+                    scrollView.contentOffset = CGPoint(x: 8, y: 12)
+
+                    let fluidFixture = makeCoreTestTransitionFixture(style: .fluid(behavior: .all), easing: .linear)
+                    let fluid = FluidTransitionScrollObserver(view: scrollView)
+                    fluid.registerParameters(parameters: fluidFixture.dismissDriver.parameters)
+                    fluid.lockScroll()
+                    scrollView.contentOffset = CGPoint(x: 80, y: 80)
+                    fluid.contentOffsetDidChange(oldValue: CGPoint(x: 0, y: -10))
+
+                    expect(scrollView.contentOffset).to(equal(CGPoint(x: 8, y: scrollView.minScrollableY)))
+
+                    fluid.unlockScroll()
+                    scrollView.contentOffset = CGPoint(x: 8, y: 12)
+
+                    let drawerFixture = makeCoreTestTransitionFixture(style: .drawer(position: .right), easing: .linear)
+                    let drawer = FluidTransitionScrollObserver(view: scrollView)
+                    drawer.registerParameters(parameters: drawerFixture.dismissDriver.parameters)
+                    drawer.lockScroll()
+                    scrollView.contentOffset = CGPoint(x: 80, y: 80)
+                    drawer.contentOffsetDidChange(oldValue: CGPoint(x: -10, y: 0))
+
+                    expect(scrollView.isUserInteractionEnabled).to(beTrue())
+                    expect(scrollView.contentOffset).to(equal(CGPoint(x: 8, y: 12)))
+
+                    drawer.unlockScroll()
+                    drawer.abortScroll()
+
+                    expect(scrollView.isScrollEnabled).to(beTrue())
+                }
+            }
+            describe("Transition gesture observer") {
+                it("updates gesture parameters, trims history, and delegates callbacks") {
+                    let delegate = TestGestureDelegate()
+                    let fixture = makeCoreTestTransitionFixture(style: .slide(direction: .fromBottom))
+                    let observer = FluidTransitionGestureObserver(delegate: delegate)
+                    let pan = StubPanGestureRecognizer()
+                    let tap = StubTapGestureRecognizer()
+                    let edgePan = StubScreenEdgePanGestureRecognizer()
+
+                    observer.registerParameters(parameters: fixture.dismissDriver.parameters)
+
+                    pan.locationValue = CGPoint(x: 10, y: 12)
+                    pan.translationValue = CGPoint(x: 0, y: 20)
+                    pan.velocityValue = CGPoint(x: 0, y: 200)
+                    observer.updateCurrentParameters(gesture: pan)
+
+                    expect(observer.initialLocation).to(equal(CGPoint(x: 10, y: 12)))
+                    expect(observer.currentTranslation).to(equal(CGPoint(x: 0, y: 20)))
+                    expect(observer.currentVelocity).to(equal(CGVector(dx: 0, dy: 200)))
+                    expect(observer.currentTranslationDirection).to(equal(.bottomCenter))
+                    expect(observer.initialGestureDirection).to(equal(.bottomCenter))
+
+                    pan.locationValue = CGPoint(x: 11, y: 13)
+                    pan.translationValue = CGPoint(x: 0, y: 24)
+                    observer.updateCurrentParameters(gesture: pan)
+                    pan.locationValue = CGPoint(x: 12, y: 14)
+                    pan.translationValue = CGPoint(x: 0, y: 28)
+                    observer.updateCurrentParameters(gesture: pan)
+                    pan.locationValue = CGPoint(x: 13, y: 15)
+                    pan.translationValue = CGPoint(x: 0, y: 32)
+                    observer.updateCurrentParameters(gesture: pan)
+
+                    expect(observer.locationHistory).to(haveCount(3))
+                    expect(observer.translationHistory).to(haveCount(3))
+                    expect(observer.averageLocation).to(equal(CGPoint(x: 12, y: 14)))
+                    expect(observer.averageTranslation).to(equal(CGPoint(x: 0, y: 28)))
+                    expect(observer.averageGestureDirection).to(equal(.bottomCenter))
+
+                    observer.updatePreviousParameters()
+
+                    expect(observer.previousLocation).to(equal(CGPoint(x: 13, y: 15)))
+                    expect(observer.previousTranslation).to(equal(CGPoint(x: 0, y: 32)))
+                    expect(observer.currentGestureDirection).to(equal(FluidGestureDirection.none))
+
+                    observer.currentVelocity = nil
+                    expect(observer.currentGestureInfo().locationLocal).to(equal(.zero))
+
+                    tap.locationValue = CGPoint(x: 20, y: 24)
+                    observer.handleTapGesture(gesture: tap)
+
+                    expect(delegate.tapUpdateCount).to(equal(1))
+                    expect(observer.currentLocation).to(equal(CGPoint(x: 20, y: 24)))
+
+                    pan.locationValue = CGPoint(x: 30, y: 32)
+                    pan.translationValue = CGPoint(x: 4, y: 0)
+                    observer.handlePanGesture(gesture: pan)
+
+                    expect(delegate.panUpdateCount).to(equal(1))
+                    expect(observer.gestureState).to(beNil())
+
+                    edgePan.locationValue = CGPoint(x: 40, y: 42)
+                    edgePan.translationValue = CGPoint(x: -6, y: 0)
+                    observer.handleEdgePanGesture(gesture: edgePan)
+
+                    expect(delegate.edgePanUpdateCount).to(equal(1))
+                    expect(observer.gestureState).to(beNil())
+                }
+
+                it("snapshots base locations and evaluates gesture routing") {
+                    let delegate = TestGestureDelegate()
+                    var retainedPanViews: [UIView] = []
+
+                    func makeObserver(style: FluidTransitionStyle) -> FluidTransitionGestureObserver {
+                        let fixture = makeCoreTestTransitionFixture(style: style, easing: .linear)
+                        let observer = FluidTransitionGestureObserver(delegate: delegate)
+                        let panGestureView = UIView(frame: CGRect(x: 10, y: 20, width: 100, height: 80))
+                        retainedPanViews.append(panGestureView)
+                        observer.registerParameters(parameters: fixture.dismissDriver.parameters)
+                        observer.baseFrame = CGRect(x: 0, y: 0, width: 120, height: 100)
+                        observer.panGestureView = panGestureView
+                        observer.currentLocation = CGPoint(x: 30, y: 40)
+                        return observer
+                    }
+
+                    let bottom = makeObserver(style: .drawer(position: .bottom))
+                    bottom.snapshotBaseParameters()
+                    expect(bottom.initialLocation).to(equal(CGPoint(x: 20, y: 20)))
+
+                    let top = makeObserver(style: .drawer(position: .top))
+                    top.snapshotBaseParameters()
+                    expect(top.initialLocation).to(equal(CGPoint(x: 30, y: 20)))
+
+                    let left = makeObserver(style: .drawer(position: .left))
+                    left.snapshotBaseParameters()
+                    expect(left.initialLocation).to(equal(CGPoint(x: 10, y: 40)))
+
+                    let right = makeObserver(style: .drawer(position: .right))
+                    right.snapshotBaseParameters()
+                    expect(right.initialLocation).to(equal(CGPoint(x: 20, y: 20)))
+
+                    let slide = makeObserver(style: .slide(direction: .fromBottom))
+                    slide.snapshotBaseParameters()
+                    expect(slide.initialLocation).to(equal(CGPoint(x: 20, y: 20)))
+                    slide.panGestureView = nil
+                    slide.snapshotBaseParameters()
+                    expect(slide.initialLocation).to(beNil())
+
+                    slide.panGestureRecognizer = StubPanGestureRecognizer()
+                    slide.edgePanGestureRecognizer = StubScreenEdgePanGestureRecognizer()
+                    slide.abortGesture()
+                    expect(slide.panGestureRecognizer.isEnabled).to(beTrue())
+                    expect(slide.edgePanGestureRecognizer?.isEnabled).to(beTrue())
+
+                    let insidePan = StubPanGestureRecognizer()
+                    insidePan.locationValue = CGPoint(x: 20, y: 20)
+                    let outsideTap = StubTapGestureRecognizer()
+                    outsideTap.locationValue = CGPoint(x: 400, y: 500)
+                    let insideTap = StubTapGestureRecognizer()
+                    insideTap.locationValue = CGPoint(x: 20, y: 20)
+                    let insideEdgePan = StubScreenEdgePanGestureRecognizer()
+                    insideEdgePan.locationValue = CGPoint(x: 20, y: 20)
+
+                    expect(slide.handleGestureRecognizerShouldBegin(outsideTap)).to(beTrue())
+                    expect(slide.handleGestureRecognizerShouldBegin(insideTap)).to(beFalse())
+                    expect(slide.handleGestureRecognizerShouldBegin(insidePan)).to(beTrue())
+                    expect(slide.handleGestureRecognizerShouldBegin(insideEdgePan)).to(beTrue())
+                    expect(slide.handleGestureRecognizer(insidePan,
+                                                         shouldRequireFailureOf: insideEdgePan)).to(beTrue())
+                    expect(slide.handleGestureRecognizer(insideEdgePan,
+                                                         shouldBeRequiredToFailBy: insidePan)).to(beTrue())
+                    expect(slide.handleGestureRecognizer(insideEdgePan,
+                                                         shouldRecognizeSimultaneouslyWith: insidePan)).to(beFalse())
+                    expect(slide.handleGestureRecognizer(insidePan,
+                                                         shouldRecognizeSimultaneouslyWith: insideTap)).to(beTrue())
                 }
             }
             describe("FluidLayoutEdgeConstant") {

--- a/Tests/UIKitSpec.swift
+++ b/Tests/UIKitSpec.swift
@@ -636,6 +636,63 @@ final class UIKitSpec: QuickSpec {
                     expect(animator.layoutContainerView.layer.maskedCorners).to(equal(animator.initialStyle.maskedCorners))
                 }
 
+                it("creates core animation fallbacks for shadow and corner masks") {
+                    let fixture = makeCoreTestTransitionFixture(style: .slide(direction: .fromBottom))
+                    let animator = fixture.presentAnimator
+                    let layoutContainerView = animator.layoutContainerView!
+                    let shadowView = FluidShadowView(shadowCornerRadius: 0,
+                                                     shadowRoundingCorners: nil,
+                                                     shadowOpacity: 0,
+                                                     shadowColor: UIColor.black.cgColor,
+                                                     shadowRadius: 0,
+                                                     shadowOffset: .zero,
+                                                     isTransparentBackground: true)
+
+                    fixture.container.addSubview(shadowView)
+                    shadowView.layer.mask = CAShapeLayer()
+                    var parameters = animator.parameters!
+                    var initialStyle = FluidInitialFrameStyle(alpha: 1,
+                                                             cornerRadius: 6,
+                                                             shadowColor: UIColor.blue.cgColor,
+                                                             shadowOpacity: 0.25,
+                                                             shadowRadius: 3,
+                                                             shadowOffset: CGSize(width: -1, height: 2))
+                    var finalStyle = FluidFinalFrameStyle(alpha: 1,
+                                                          cornerRadius: 18,
+                                                          cornerStyle: .bottom,
+                                                          shadowColor: UIColor.red.cgColor,
+                                                          shadowOpacity: 0.75,
+                                                          shadowRadius: 9,
+                                                          shadowOffset: CGSize(width: 3, height: 4))
+                    initialStyle.isTransparentBackground = true
+                    finalStyle.isTransparentBackground = true
+                    parameters.layoutContainerView = layoutContainerView
+                    parameters.shadowView = shadowView
+                    parameters.shouldCastShadow = true
+                    parameters.shouldMaskCorner = true
+                    parameters.initialStyle = initialStyle
+                    parameters.finalStyle = finalStyle
+                    animator.parameters = parameters
+
+                    let expectedShadowFrame = animator.toShadowFrame(false, 0)
+                    let shadowAnimators = animator.createShadowCoreAnimation(false)
+                    let cornerAnimators = animator.createCornerRadiusCoreAnimation(false)
+
+                    expect(shadowAnimators.count).to(equal(2))
+                    expect((shadowAnimators.first as? FluidCoreAnimator)?.animationCount).to(equal(8))
+                    expect((shadowAnimators.last as? FluidCoreAnimator)?.animationCount).to(equal(1))
+                    expect(cornerAnimators.count).to(equal(1))
+                    expect((cornerAnimators.first as? FluidCoreAnimator)?.animationCount).to(equal(1))
+                    expect(shadowView.layer.frame).to(equal(expectedShadowFrame))
+                    expect(shadowView.layer.cornerRadius).to(beCloseTo(18))
+                    expect(CGFloat(shadowView.layer.shadowOpacity)).to(beCloseTo(0.75, within: 0.001))
+                    expect(shadowView.layer.shadowRadius).to(beCloseTo(9))
+                    expect(shadowView.layer.shadowOffset).to(equal(CGSize(width: 3, height: 4)))
+                    expect(shadowView.layer.shadowPath).notTo(beNil())
+                    expect(shadowView.layer.mask as? CAShapeLayer).notTo(beNil())
+                    expect(animator.layoutContainerView.layer.mask as? FluidCornerMaskLayer).notTo(beNil())
+                }
+
                 it("invalidates animator state and removes transient views") {
                     let fixture = makeCoreTestTransitionFixture()
                     let animator = fixture.presentAnimator
@@ -735,6 +792,43 @@ final class UIKitSpec: QuickSpec {
                     expect(layer.mask as? CAShapeLayer).notTo(beNil())
                     expect(FluidShadowLayer.needsDisplay(forKey: "shadowCornerRadius")).to(beTrue())
                     expect(FluidShadowLayer.needsDisplay(forKey: "isTransparentBackground")).to(beTrue())
+                }
+            }
+            describe("FluidCornerMaskLayer") {
+                it("updates mask paths and preserves copied mask state") {
+                    let initialBounds = CGRect(x: 0, y: 0, width: 100, height: 80)
+                    let updatedBounds = CGRect(x: 0, y: 0, width: 120, height: 90)
+                    let layer = FluidCornerMaskLayer(bounds: initialBounds,
+                                                     cornerRadius: 8,
+                                                     roundingCorners: [.topLeft, .topRight])
+
+                    expect(layer.frame).to(equal(initialBounds))
+                    expect(layer.fluidCornerRadius).to(beCloseTo(8))
+                    expect(layer.fluidRoundingCorners).to(equal([.topLeft, .topRight]))
+                    expect(layer.path).notTo(beNil())
+
+                    layer.updateMaskPath(bounds: updatedBounds,
+                                         cornerRadius: 14,
+                                         roundingCorners: [.bottomLeft, .bottomRight])
+
+                    expect(layer.fluidCornerRadius).to(beCloseTo(14))
+                    expect(layer.fluidRoundingCorners).to(equal([.bottomLeft, .bottomRight]))
+                    expect(layer.path?.boundingBoxOfPath).to(equal(updatedBounds))
+
+                    layer.bounds = CGRect(x: 0, y: 0, width: 60, height: 40)
+
+                    expect(layer.path?.boundingBoxOfPath).to(equal(CGRect(x: 0, y: 0, width: 60, height: 40)))
+
+                    let copied = FluidCornerMaskLayer(layer: layer)
+
+                    expect(copied.frame).to(equal(layer.frame))
+                    expect(copied.fluidCornerRadius).to(beCloseTo(layer.fluidCornerRadius))
+                    expect(copied.fluidRoundingCorners).to(equal(layer.fluidRoundingCorners))
+                    expect(copied.path).notTo(beNil())
+                    expect(FluidCornerMaskLayer.createMaskPath(bounds: initialBounds,
+                                                               cornerRadius: 8,
+                                                               roundingCorners: .topLeft).boundingBoxOfPath)
+                        .to(equal(initialBounds))
                 }
             }
             describe("Navigation interactive animator") {

--- a/Tests/UIKitSpec.swift
+++ b/Tests/UIKitSpec.swift
@@ -603,6 +603,57 @@ final class UIKitSpec: QuickSpec {
                     expect(rotateFixture.dismissDriver.parameters.animationType).to(equal(.dismiss))
                     expect(rotateFixture.dismissDriver.observingGesture).notTo(beNil())
                 }
+
+                it("cleans up present animation completion and cancellation") {
+                    let completedFixture = makeCoreTestTransitionFixture()
+                    completedFixture.presentDriver.interruptibleAnimator = UIViewPropertyAnimator(duration: 0, curve: .linear)
+
+                    completedFixture.presentDriver.animationDidEnd(true)
+
+                    expect(completedFixture.sourceDelegate.presentAnimationStates.map { String(describing: $0) }).to(equal(["end"]))
+                    expect(completedFixture.destinationDelegate.presentAnimationStates.map { String(describing: $0) }).to(equal(["end"]))
+                    expect(completedFixture.presentDriver.interruptibleAnimator).to(beNil())
+                    expect(completedFixture.presentDriver.observingGesture).to(beNil())
+                    expect(completedFixture.presentAnimator.parameters).to(beNil())
+
+                    let cancelledFixture = makeCoreTestTransitionFixture()
+                    cancelledFixture.presentDriver.interruptibleAnimator = UIViewPropertyAnimator(duration: 0, curve: .linear)
+
+                    cancelledFixture.presentDriver.animationDidEnd(false)
+
+                    expect(cancelledFixture.sourceDelegate.presentAnimationStates.map { String(describing: $0) }).to(equal(["cancel"]))
+                    expect(cancelledFixture.destinationDelegate.presentAnimationStates.map { String(describing: $0) }).to(equal(["cancel"]))
+                    expect(cancelledFixture.presentDriver.interruptibleAnimator).to(beNil())
+                    expect(cancelledFixture.presentDriver.observingGesture).to(beNil())
+                    expect(cancelledFixture.presentAnimator.parameters).to(beNil())
+                    expect(cancelledFixture.destinationViewController.view.superview).to(beNil())
+                }
+
+                it("cleans up dismiss animation completion and restores cancellation parameters") {
+                    let completedFixture = makeCoreTestTransitionFixture()
+                    completedFixture.dismissDriver.interruptibleAnimator = UIViewPropertyAnimator(duration: 0, curve: .linear)
+
+                    completedFixture.dismissDriver.animationDidEnd(true)
+
+                    expect(completedFixture.sourceDelegate.dismissAnimationStates.map { String(describing: $0) }).to(equal(["end"]))
+                    expect(completedFixture.destinationDelegate.dismissAnimationStates.map { String(describing: $0) }).to(equal(["end"]))
+                    expect(completedFixture.dismissDriver.interruptibleAnimator).to(beNil())
+                    expect(completedFixture.dismissDriver.observingGesture).to(beNil())
+                    expect(completedFixture.dismissAnimator.parameters).to(beNil())
+                    expect(completedFixture.destinationViewController.view.superview).to(beNil())
+
+                    let cancelledFixture = makeCoreTestTransitionFixture()
+                    cancelledFixture.dismissDriver.interruptibleAnimator = UIViewPropertyAnimator(duration: 0, curve: .linear)
+
+                    cancelledFixture.dismissDriver.animationDidEnd(false)
+
+                    expect(cancelledFixture.sourceDelegate.dismissAnimationStates.map { String(describing: $0) }).to(equal(["cancel"]))
+                    expect(cancelledFixture.destinationDelegate.dismissAnimationStates.map { String(describing: $0) }).to(equal(["cancel"]))
+                    expect(cancelledFixture.dismissDriver.interruptibleAnimator).to(beNil())
+                    expect(cancelledFixture.dismissDriver.parameters.animationType).to(equal(.dismiss))
+                    expect(cancelledFixture.dismissAnimator.parameters).notTo(beNil())
+                    expect(cancelledFixture.destinationViewController.view.superview).notTo(beNil())
+                }
             }
             describe("Core animator helpers") {
                 it("converts delayed transition progress into animator progress") {

--- a/Tests/UIKitSpec.swift
+++ b/Tests/UIKitSpec.swift
@@ -414,6 +414,117 @@ final class UIKitSpec: QuickSpec {
                     expect(blockedFixture.dismissDriver.canBeginDismissInteraction(isEdgePan: false)).to(beFalse())
                 }
             }
+            describe("Core animator helpers") {
+                it("converts delayed transition progress into animator progress") {
+                    let fixture = makeCoreTestTransitionFixture()
+                    let animator = fixture.presentAnimator
+
+                    expect(animator.convertProgress(transitionProgress: 0.2,
+                                                    transitionDuration: 2,
+                                                    animatorDuration: 1,
+                                                    animatorDelay: 0.5)).to(beCloseTo(0))
+                    expect(animator.convertProgress(transitionProgress: 0.25,
+                                                    transitionDuration: 2,
+                                                    animatorDuration: 1,
+                                                    animatorDelay: 0.5)).to(beCloseTo(0))
+                    expect(animator.convertProgress(transitionProgress: 0.625,
+                                                    transitionDuration: 2,
+                                                    animatorDuration: 1,
+                                                    animatorDelay: 0.5)).to(beCloseTo(0.75, within: 0.001))
+                    expect(animator.convertProgress(transitionProgress: 1,
+                                                    transitionDuration: 2,
+                                                    animatorDuration: 1,
+                                                    animatorDelay: 0.5)).to(beCloseTo(1))
+                }
+
+                it("applies shadow layer properties and transparent masks") {
+                    let fixture = makeCoreTestTransitionFixture()
+                    let shadowView = FluidShadowView(shadowCornerRadius: 0,
+                                                     shadowRoundingCorners: nil,
+                                                     shadowOpacity: 0,
+                                                     shadowColor: UIColor.black.cgColor,
+                                                     shadowRadius: 0,
+                                                     shadowOffset: .zero,
+                                                     isTransparentBackground: false)
+                    let frame = CGRect(x: 12, y: 20, width: 120, height: 80)
+                    let shadowOffset = CGSize(width: 3, height: -2)
+
+                    fixture.container.addSubview(shadowView)
+                    fixture.presentAnimator.parameters.shadowView = shadowView
+                    shadowView.layer.mask = CAShapeLayer()
+
+                    fixture.presentAnimator.applyShadowProperties(frame: frame,
+                                                                  cornerRadius: 10,
+                                                                  cornerStyle: .top,
+                                                                  shadowColor: UIColor.red.cgColor,
+                                                                  shadowOpacity: 0.65,
+                                                                  shadowRadius: 6,
+                                                                  shadowOffset: shadowOffset,
+                                                                  isTransparentBackground: true)
+
+                    expect(shadowView.layer.frame).to(equal(frame))
+                    expect(shadowView.layer.cornerRadius).to(beCloseTo(10))
+                    expect(CGFloat(shadowView.layer.shadowOpacity)).to(beCloseTo(0.65, within: 0.001))
+                    expect(shadowView.layer.shadowRadius).to(beCloseTo(6))
+                    expect(shadowView.layer.shadowOffset).to(equal(shadowOffset))
+                    expect(shadowView.layer.shadowPath).notTo(beNil())
+                    expect((shadowView.layer.mask as? CAShapeLayer)?.path).notTo(beNil())
+                }
+            }
+            describe("FluidShadowLayer") {
+                it("creates expanded shadow frames and optional masks") {
+                    let frame = CGRect(x: 10, y: 20, width: 100, height: 80)
+                    let shadowOffset = CGSize(width: 2, height: -3)
+
+                    let shadowFrame = FluidShadowLayer.createShadowFrame(frame: frame,
+                                                                         shadowRadius: 4,
+                                                                         shadowOffset: shadowOffset)
+
+                    expect(shadowFrame).to(equal(CGRect(x: 4, y: 9, width: 116, height: 96)))
+                    expect(FluidShadowLayer.createShadowMask(bounds: frame.bounds,
+                                                             cornerRadius: 8,
+                                                             roundingCorners: [.topLeft, .topRight],
+                                                             shadowRadius: 4,
+                                                             shadowOffset: shadowOffset,
+                                                             isTransparentBackground: false)).to(beNil())
+
+                    let mask = FluidShadowLayer.createShadowMask(bounds: frame.bounds,
+                                                                 cornerRadius: 8,
+                                                                 roundingCorners: [.topLeft, .topRight],
+                                                                 shadowRadius: 4,
+                                                                 shadowOffset: shadowOffset,
+                                                                 isTransparentBackground: true)
+
+                    expect(mask?.frame).to(equal(CGRect(x: 0, y: 0, width: 116, height: 96)))
+                    expect(mask?.path).notTo(beNil())
+                }
+
+                it("casts shadow and marks animatable keys for display") {
+                    let layer = FluidShadowLayer(frame: .zero)
+                    let frame = CGRect(x: 0, y: 0, width: 90, height: 70)
+                    let shadowOffset = CGSize(width: -2, height: 5)
+
+                    layer.castShadow(frame: frame,
+                                     shadowCornerRadius: 12,
+                                     shadowRoundingCorners: .bottomRight,
+                                     shadowColor: UIColor.blue.cgColor,
+                                     shadowOpacity: 0.55,
+                                     shadowRadius: 5,
+                                     shadowOffset: shadowOffset,
+                                     isTransparentBackground: true)
+
+                    expect(layer.shadowCornerRadius).to(beCloseTo(12))
+                    expect(layer.shadowRoundingCorners).to(equal(.bottomRight))
+                    expect(CGFloat(layer.shadowOpacity)).to(beCloseTo(0.55, within: 0.001))
+                    expect(layer.shadowRadius).to(beCloseTo(5))
+                    expect(layer.shadowOffset).to(equal(shadowOffset))
+                    expect(layer.isTransparentBackground).to(beTrue())
+                    expect(layer.shadowPath).notTo(beNil())
+                    expect(layer.mask as? CAShapeLayer).notTo(beNil())
+                    expect(FluidShadowLayer.needsDisplay(forKey: "shadowCornerRadius")).to(beTrue())
+                    expect(FluidShadowLayer.needsDisplay(forKey: "isTransparentBackground")).to(beTrue())
+                }
+            }
             describe("FluidLayoutEdgeConstant") {
                 it("calculates edge constants from container size and frame") {
                     let constants = FluidLayoutEdgeConstant(

--- a/Tests/VectorMathSpec.swift
+++ b/Tests/VectorMathSpec.swift
@@ -11,18 +11,245 @@ import Nimble
 import UIKit
 @testable import Fluidable
 
-//class VectorMathSpec: QuickSpec {
-//    override class func spec() {
-//        describe("VectorMath") {
-//            describe("Scalar") {
-//                it("Property") {
-//                    let scalar0: Scalar = 0.00000
-//                    let scalar1: Scalar = 0.00001
-//                    expect(scalar0 ~= scalar1).to(beTrue())
-//                    expect(Scalar(0.1).sign == Scalar(1)).to(beTrue())
-//                    expect(Scalar(-0.1).sign == Scalar(-1)).to(beTrue())
-//                }
-//            }
-//        }
-//    }
-//}
+final class VectorMathSpec: QuickSpec {
+    override class func spec() {
+        describe("VectorMath") {
+            describe("Scalar") {
+                it("compares nearby values") {
+                    let scalar0: Scalar = 0.00000
+                    let scalar1: Scalar = 0.00001
+                    let scalar2: Scalar = 0.00100
+
+                    expect(scalar0 ~= scalar1).to(beTrue())
+                    expect(scalar0 ~= scalar2).to(beFalse())
+                    expect(Scalar.degreesPerRadian * Scalar.radiansPerDegree).to(beCloseTo(1, within: 0.001))
+                }
+            }
+
+            describe("Vector2") {
+                it("calculates geometry and applies matrix transforms") {
+                    let vector = Vector2(3, 4)
+                    let other = Vector2([1, 2])
+                    let translation = Matrix3(translation: Vector2(2, 3))
+                    let scale = Matrix3(scale: Vector2(2, 3))
+
+                    expect(Set([Vector2.x, Vector2.y]).contains(Vector2.x)).to(beTrue())
+                    expect(Vector2.zero.toArray()).to(equal([0, 0]))
+                    expect(vector.lengthSquared).to(equal(25))
+                    expect(vector.length).to(equal(5))
+                    expect(vector.inverse).to(equal(Vector2(-3, -4)))
+                    expect(other.toArray()).to(equal([1, 2]))
+                    expect(vector.dot(other)).to(equal(11))
+                    expect(vector.cross(other)).to(equal(2))
+                    expect(Vector2.zero.normalized()).to(equal(Vector2.zero))
+                    expect(Vector2.x.normalized()).to(equal(Vector2.x))
+                    expect(Vector2(3, 4).normalized() ~= Vector2(0.6, 0.8)).to(beTrue())
+                    expect(Vector2.x.rotated(by: .halfPi) ~= Vector2(0, 1)).to(beTrue())
+                    expect(Vector2(2, 1).rotated(by: .halfPi, around: Vector2(1, 1)) ~= Vector2(1, 2)).to(beTrue())
+                    expect(Vector2.x.angle(with: Vector2.x)).to(equal(0))
+                    expect(Vector2.x.angle(with: Vector2.y)).to(beCloseTo(.halfPi, within: 0.001))
+                    expect(Vector2.zero.interpolated(with: Vector2(10, 20), by: 0.25)).to(equal(Vector2(2.5, 5)))
+                    expect(-other).to(equal(Vector2(-1, -2)))
+                    expect(vector + other).to(equal(Vector2(4, 6)))
+                    expect(vector - other).to(equal(Vector2(2, 2)))
+                    expect(vector * other).to(equal(Vector2(3, 8)))
+                    expect(other * 2).to(equal(Vector2(2, 4)))
+                    expect(vector / Vector2(3, 2)).to(equal(Vector2(1, 2)))
+                    expect(vector / 2).to(equal(Vector2(1.5, 2)))
+                    expect(Vector2(1, 1) * translation).to(equal(Vector2(3, 4)))
+                    expect(scale * Vector2(2, 3)).to(equal(Vector2(4, 9)))
+                    expect(Vector2(2, 3) ~= Vector2(2.00001, 2.99999)).to(beTrue())
+                }
+            }
+
+            describe("Vector3") {
+                it("calculates vector products and component views") {
+                    var vector = Vector3(1, 2, 3)
+                    let other = Vector3([4, 5, 6])
+                    let matrix3 = Matrix3(scale: Vector2(2, 3))
+                    let matrix4 = Matrix4(translation: Vector3(10, 20, 30))
+                    let quaternion = Quaternion(axisAngle: Vector4(0, 0, 1, .halfPi))
+
+                    expect(Set([Vector3.x, Vector3.y, Vector3.z]).contains(Vector3.z)).to(beTrue())
+                    expect(Vector3.zero.toArray()).to(equal([0, 0, 0]))
+                    expect(vector.lengthSquared).to(equal(14))
+                    expect(vector.length).to(beCloseTo(sqrt(14), within: 0.001))
+                    expect(vector.inverse).to(equal(Vector3(-1, -2, -3)))
+                    expect(vector.xy).to(equal(Vector2(1, 2)))
+                    expect(vector.xz).to(equal(Vector2(1, 3)))
+                    expect(vector.yz).to(equal(Vector2(2, 3)))
+
+                    vector.xy = Vector2(7, 8)
+                    vector.xz = Vector2(9, 10)
+                    vector.yz = Vector2(11, 12)
+
+                    expect(vector).to(equal(Vector3(9, 11, 12)))
+                    expect(other.toArray()).to(equal([4, 5, 6]))
+                    expect(vector.dot(other)).to(equal(163))
+                    expect(Vector3.x.cross(Vector3.y)).to(equal(Vector3.z))
+                    expect(Vector3.zero.normalized()).to(equal(Vector3.zero))
+                    expect(Vector3.x.normalized()).to(equal(Vector3.x))
+                    expect(Vector3(2, 0, 0).normalized()).to(equal(Vector3.x))
+                    expect(Vector3.zero.interpolated(with: Vector3(10, 20, 30), by: 0.5)).to(equal(Vector3(5, 10, 15)))
+                    expect(-other).to(equal(Vector3(-4, -5, -6)))
+                    expect(other + Vector3(1, 1, 1)).to(equal(Vector3(5, 6, 7)))
+                    expect(other - Vector3(1, 2, 3)).to(equal(Vector3(3, 3, 3)))
+                    expect(other * Vector3(2, 3, 4)).to(equal(Vector3(8, 15, 24)))
+                    expect(other * 2).to(equal(Vector3(8, 10, 12)))
+                    expect(Vector3(1, 1, 1) * matrix3).to(equal(Vector3(2, 3, 1)))
+                    expect(Vector3(1, 1, 1) * matrix4).to(equal(Vector3(11, 21, 31)))
+                    expect((Vector3.x * quaternion) ~= Vector3(0, 1, 0)).to(beTrue())
+                    expect(other / Vector3(2, 5, 3)).to(equal(Vector3(2, 1, 2)))
+                    expect(other / 2).to(equal(Vector3(2, 2.5, 3)))
+                    expect(Vector3(1, 2, 3) ~= Vector3(1.00001, 2.00001, 2.99999)).to(beTrue())
+                }
+            }
+
+            describe("Vector4") {
+                it("calculates homogeneous vectors and transforms") {
+                    var vector = Vector4(1, 2, 3, 2)
+                    let other = Vector4([4, 5, 6, 7])
+                    let matrix = Matrix4(translation: Vector3(10, 20, 30))
+
+                    expect(Set([Vector4.x, Vector4.y, Vector4.z, Vector4.w]).contains(Vector4.w)).to(beTrue())
+                    expect(Vector4.zero.toArray()).to(equal([0, 0, 0, 0]))
+                    expect(vector.lengthSquared).to(equal(18))
+                    expect(vector.length).to(beCloseTo(sqrt(18), within: 0.001))
+                    expect(vector.inverse).to(equal(Vector4(-1, -2, -3, -2)))
+                    expect(vector.xyz).to(equal(Vector3(1, 2, 3)))
+                    expect(vector.xy).to(equal(Vector2(1, 2)))
+                    expect(vector.xz).to(equal(Vector2(1, 3)))
+                    expect(vector.yz).to(equal(Vector2(2, 3)))
+
+                    vector.xyz = Vector3(7, 8, 9)
+                    vector.xy = Vector2(10, 11)
+                    vector.xz = Vector2(12, 13)
+                    vector.yz = Vector2(14, 15)
+
+                    expect(vector).to(equal(Vector4(12, 14, 15, 2)))
+                    expect(Vector4(Vector3(1, 2, 3), w: 4).toArray()).to(equal([1, 2, 3, 4]))
+                    expect(Vector4(2, 4, 6, 2).toVector3()).to(equal(Vector3(1, 2, 3)))
+                    expect(Vector4(2, 4, 6, 0).toVector3()).to(equal(Vector3(2, 4, 6)))
+                    expect(other.dot(Vector4(1, 1, 1, 1))).to(equal(22))
+                    expect(Vector4.zero.normalized()).to(equal(Vector4.zero))
+                    expect(Vector4.x.normalized()).to(equal(Vector4.x))
+                    expect(Vector4(2, 0, 0, 0).normalized()).to(equal(Vector4.x))
+                    expect(Vector4.zero.interpolated(with: Vector4(10, 20, 30, 40), by: 0.5)).to(equal(Vector4(5, 10, 15, 20)))
+                    expect(-other).to(equal(Vector4(-4, -5, -6, -7)))
+                    expect(other + Vector4(1, 1, 1, 1)).to(equal(Vector4(5, 6, 7, 8)))
+                    expect(other - Vector4(1, 2, 3, 4)).to(equal(Vector4(3, 3, 3, 3)))
+                    expect(other * Vector4(2, 3, 4, 5)).to(equal(Vector4(8, 15, 24, 35)))
+                    expect(other * 2).to(equal(Vector4(8, 10, 12, 14)))
+                    expect(Vector4(1, 2, 3, 1) * matrix).to(equal(Vector4(11, 22, 33, 1)))
+                    expect(other / Vector4(2, 5, 3, 7)).to(equal(Vector4(2, 1, 2, 1)))
+                    expect(other / 2).to(equal(Vector4(2, 2.5, 3, 3.5)))
+                    expect(Vector4(1, 2, 3, 4) ~= Vector4(1.00001, 2.00001, 2.99999, 4.00001)).to(beTrue())
+                }
+            }
+
+            describe("Matrix3") {
+                it("builds, interpolates, and inverts affine matrices") {
+                    let matrix = Matrix3([1, 2, 3, 0, 1, 4, 5, 6, 0])
+                    let scale = Matrix3(scale: Vector2(2, 3))
+                    let translation = Matrix3(translation: Vector2(4, 5))
+                    let rotation = Matrix3(rotation: .halfPi)
+
+                    expect(Set([Matrix3.identity]).contains(Matrix3.identity)).to(beTrue())
+                    expect(matrix.toArray()).to(equal([1, 2, 3, 0, 1, 4, 5, 6, 0]))
+                    expect(scale.toArray()).to(equal([2, 0, 0, 0, 3, 0, 0, 0, 1]))
+                    expect(translation.toArray()).to(equal([1, 0, 0, 0, 1, 0, 4, 5, 1]))
+                    expect((Vector2.x * rotation) ~= Vector2(0, 1)).to(beTrue())
+                    expect(matrix.adjugate.toArray()).notTo(beEmpty())
+                    expect(matrix.determinant).to(equal(1))
+                    expect(matrix.transpose.transpose).to(equal(matrix))
+                    expect((matrix * matrix.inverse) ~= Matrix3.identity).to(beTrue())
+                    expect(matrix.interpolated(with: Matrix3.identity, by: 0).toArray()).to(equal(matrix.toArray()))
+                    expect(-matrix ~= matrix.inverse).to(beTrue())
+                    expect((translation * scale).toArray()).notTo(beEmpty())
+                    expect(Matrix3.identity * Vector3(1, 2, 3)).to(equal(Vector3(1, 2, 3)))
+                    expect((matrix * 2).toArray()).to(equal([2, 4, 6, 0, 2, 8, 10, 12, 0]))
+                    expect(matrix == Matrix3.identity).to(beFalse())
+                    expect(matrix ~= Matrix3([1.00001, 2, 3, 0, 1, 4, 5, 6, 0])).to(beTrue())
+                }
+            }
+
+            describe("Matrix4") {
+                it("builds projection and transform matrices") {
+                    let matrix = Matrix4([1, 0, 0, 0, 0, 2, 0, 0, 0, 0, 3, 0, 4, 5, 6, 1])
+                    let scale = Matrix4(scale: Vector3(2, 3, 4))
+                    let translation = Matrix4(translation: Vector3(10, 20, 30))
+                    let rotation = Matrix4(rotation: Vector4(0, 0, 1, .halfPi))
+                    let quaternion = Matrix4(quaternion: Quaternion(axisAngle: Vector4(0, 0, 1, .halfPi)))
+                    let perspectiveXy = Matrix4(fovx: 1, fovy: 1, near: 1, far: 10)
+                    let perspectiveAspectX = Matrix4(fovx: 1, aspect: 1, near: 1, far: 10)
+                    let perspectiveAspectY = Matrix4(fovy: 1, aspect: 1, near: 1, far: 10)
+                    let orthographic = Matrix4(top: 1, right: 1, bottom: -1, left: -1, near: 1, far: 10)
+
+                    expect(Set([Matrix4.identity]).contains(Matrix4.identity)).to(beTrue())
+                    expect(matrix.toArray()).to(equal([1, 0, 0, 0, 0, 2, 0, 0, 0, 0, 3, 0, 4, 5, 6, 1]))
+                    expect(scale.toArray()).to(equal([2, 0, 0, 0, 0, 3, 0, 0, 0, 0, 4, 0, 0, 0, 0, 1]))
+                    expect(translation.toArray()).to(equal([1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 10, 20, 30, 1]))
+                    expect((Vector3.x * rotation) ~= Vector3(0, 1, 0)).to(beTrue())
+                    expect((Vector3.x * quaternion) ~= Vector3(0, 1, 0)).to(beTrue())
+                    expect(perspectiveXy.toArray()).notTo(beEmpty())
+                    expect(perspectiveAspectX.toArray()).to(equal(perspectiveAspectY.toArray()))
+                    expect(orthographic.toArray()).notTo(beEmpty())
+                    expect(matrix.adjugate.toArray()).notTo(beEmpty())
+                    expect(matrix.determinant).to(equal(6))
+                    expect(matrix.transpose.transpose).to(equal(matrix))
+                    expect((matrix * matrix.inverse) ~= Matrix4.identity).to(beTrue())
+                    expect(-matrix ~= matrix.inverse).to(beTrue())
+                    expect((translation * scale).toArray()).notTo(beEmpty())
+                    expect(Matrix4.identity * Vector3(1, 2, 3)).to(equal(Vector3(1, 2, 3)))
+                    expect(Matrix4.identity * Vector4(1, 2, 3, 4)).to(equal(Vector4(1, 2, 3, 4)))
+                    expect((matrix * 2).toArray()).to(equal([2, 0, 0, 0, 0, 4, 0, 0, 0, 0, 6, 0, 8, 10, 12, 2]))
+                    expect(matrix == Matrix4.identity).to(beFalse())
+                    expect(matrix ~= Matrix4([1.00001, 0, 0, 0, 0, 2, 0, 0, 0, 0, 3, 0, 4, 5, 6, 1])).to(beTrue())
+                }
+            }
+
+            describe("Quaternion") {
+                it("converts between rotations and interpolates") {
+                    var quaternion = Quaternion(1, 2, 3, 4)
+                    let axisAngle = Vector4(0, 0, 1, .halfPi)
+                    let rotation = Quaternion(axisAngle: axisAngle)
+                    let euler = Quaternion(pitch: 0.2, yaw: 0.3, roll: 0.4)
+                    let fromMatrix = Quaternion(rotationMatrix: Matrix4(rotation: axisAngle))
+                    let fromArray = Quaternion([1, 2, 3, 4])
+
+                    expect(Set([Quaternion.identity, Quaternion.zero]).contains(Quaternion.identity)).to(beTrue())
+                    expect(quaternion.lengthSquared).to(equal(30))
+                    expect(quaternion.length).to(beCloseTo(sqrt(30), within: 0.001))
+                    expect(quaternion.inverse).to(equal(Quaternion(-1, -2, -3, 4)))
+                    expect(quaternion.xyz).to(equal(Vector3(1, 2, 3)))
+
+                    quaternion.xyz = Vector3(5, 6, 7)
+
+                    expect(quaternion).to(equal(Quaternion(5, 6, 7, 4)))
+                    expect(euler.pitch).to(beCloseTo(0.2, within: 0.001))
+                    expect(euler.yaw).to(beCloseTo(0.3, within: 0.001))
+                    expect(euler.roll).to(beCloseTo(0.4, within: 0.001))
+                    expect(fromMatrix.toArray()).notTo(beEmpty())
+                    expect(fromArray.toArray()).to(equal([1, 2, 3, 4]))
+                    expect(rotation.toAxisAngle() ~= axisAngle).to(beTrue())
+                    expect(Quaternion.identity.toAxisAngle()).to(equal(Vector4.z))
+                    expect(euler.toPitchYawRoll().pitch).to(beCloseTo(0.2, within: 0.001))
+                    expect(Quaternion.identity.dot(Quaternion.identity)).to(equal(1))
+                    expect(Quaternion.zero.normalized()).to(equal(Quaternion.zero))
+                    expect(Quaternion.identity.normalized()).to(equal(Quaternion.identity))
+                    expect(Quaternion(2, 0, 0, 0).normalized()).to(equal(Quaternion(1, 0, 0, 0)))
+                    expect(Quaternion.identity.interpolated(with: Quaternion.identity, by: 0.5)).to(equal(Quaternion.identity))
+                    expect(Quaternion.identity.interpolated(with: rotation, by: 0.5).length).to(beCloseTo(1, within: 0.001))
+                    expect(-rotation ~= Quaternion(0, 0, -rotation.z, rotation.w)).to(beTrue())
+                    expect(rotation + Quaternion.identity).to(equal(Quaternion(rotation.x, rotation.y, rotation.z, rotation.w + 1)))
+                    expect(rotation - Quaternion.identity).to(equal(Quaternion(rotation.x, rotation.y, rotation.z, rotation.w - 1)))
+                    expect((rotation * Quaternion.identity) ~= rotation).to(beTrue())
+                    expect((rotation * Vector3.x) ~= Vector3(0, 1, 0)).to(beTrue())
+                    expect((rotation * 2).toArray()).to(equal([rotation.x * 2, rotation.y * 2, rotation.z * 2, rotation.w * 2]))
+                    expect((rotation / 2).toArray()).to(equal([rotation.x / 2, rotation.y / 2, rotation.z / 2, rotation.w / 2]))
+                    expect(rotation ~= Quaternion(rotation.x, rotation.y, rotation.z, rotation.w + 0.00001)).to(beTrue())
+                }
+            }
+        }
+    }
+}

--- a/UITests/MainSpec+Transition.swift
+++ b/UITests/MainSpec+Transition.swift
@@ -17,20 +17,7 @@ extension MainSpec {
         let collectionView: XCUIElement = app.collectionViews.element(matching: .collectionView, identifier: "rootCollectionView")
         self.assertEventually(collectionView.exists)
         /* NOTE: Scroll until the collection targetView is found */
-        if model == .transitionFluidModal {
-            self.tapRootCollectionCell(collectionView, app: app, model: model)
-        } else {
-            var collectionCell: XCUIElement!
-            while (true) {
-                collectionCell = collectionView.cells.element(matching: .cell, identifier: model.rootCellAccessibilityIdentifier)
-                if collectionCell.isVisible {
-                    collectionCell.tapVisibleCenter()
-                    break
-                } else {
-                    collectionView.swipeUp()
-                }
-            }
-        }
+        self.tapRootCollectionCell(collectionView, app: app, model: model)
         self.waitForPresentedController(app: app, model: model)
     }
 
@@ -41,11 +28,12 @@ extension MainSpec {
                 let windowFrame = app.windows.element(boundBy: 0).frame
                 let visibleCollectionFrame = collectionView.frame.intersection(windowFrame)
                 let centerY = collectionCell.frame.midY
-                let topInset = visibleCollectionFrame.minY + min(24, visibleCollectionFrame.height * 0.1)
-                let bottomInset = visibleCollectionFrame.maxY - min(24, visibleCollectionFrame.height * 0.1)
+                let safeInset = min(72, visibleCollectionFrame.height * 0.2)
+                let topInset = visibleCollectionFrame.minY + safeInset
+                let bottomInset = visibleCollectionFrame.maxY - safeInset
 
                 if centerY >= topInset && centerY <= bottomInset {
-                    collectionCell.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.5)).tap()
+                    collectionCell.tapVisibleCenter()
                     return
                 }
 


### PR DESCRIPTION
## Summary
- Adds targeted Unit tests for animator, driver, layout, vector math, gesture observer, and progress layer behavior identified by the #19 Codecov inventory.
- Raises local xccov `Fluidable.framework` line coverage above the short-term 80% target without coverage exclusions.
- Keeps UI test expansion out of this PR; this branch focuses on meaningful Unit coverage additions.

## Test Plan
- `xcodebuild test -project Fluidable.xcodeproj -scheme Fluidable -destination 'platform=iOS Simulator,name=iPhone 17,OS=26.5' -only-testing:FluidableTests/QuartzCoreSpec -enableCodeCoverage YES -resultBundlePath Reports/coverage/unit-progress-layer-focused-5.xcresult`
- `xcodebuild test -project Fluidable.xcodeproj -scheme Fluidable -destination 'platform=iOS Simulator,name=iPhone 17,OS=26.5' -only-testing:FluidableTests -enableCodeCoverage YES -resultBundlePath Reports/coverage/unit-progress-layer-full-3.xcresult`
- `git diff --check`
- `xcrun xccov view --report --json Reports/coverage/unit-progress-layer-full-3.xcresult` => `Fluidable.framework: 80.04% (9361/11696)`