### PR TITLE
fix(example): clean startup warnings

### DIFF
--- a/Example/Info.plist
+++ b/Example/Info.plist
@@ -22,8 +22,25 @@
 	<true/>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
-	<key>UIMainStoryboardFile</key>
-	<string>Main</string>
+	<key>UIApplicationSceneManifest</key>
+	<dict>
+		<key>UIApplicationSupportsMultipleScenes</key>
+		<false/>
+		<key>UISceneConfigurations</key>
+		<dict>
+			<key>UIWindowSceneSessionRoleApplication</key>
+			<array>
+				<dict>
+					<key>UISceneConfigurationName</key>
+					<string>Default Configuration</string>
+					<key>UISceneDelegateClassName</key>
+					<string>$(PRODUCT_MODULE_NAME).SceneDelegate</string>
+					<key>UISceneStoryboardFile</key>
+					<string>Main</string>
+				</dict>
+			</array>
+		</dict>
+	</dict>
 	<key>UIRequiredDeviceCapabilities</key>
 	<array>
 		<string>armv7</string>

--- a/Example/Source/AppDelegate.swift
+++ b/Example/Source/AppDelegate.swift
@@ -12,8 +12,6 @@ import Fluidable
 @UIApplicationMain
 class AppDelegate: UIResponder, UIApplicationDelegate {
 
-    var window: UIWindow?
-
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         /* NOTE: 🌊 Initialize `Fluidable` */
         FluidableInit()
@@ -22,26 +20,9 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         return true
     }
 
-    func applicationWillResignActive(_ application: UIApplication) {
-        // Sent when the application is about to move from active to inactive state. This can occur for certain types of temporary interruptions (such as an incoming phone call or SMS message) or when the user quits the application and it begins the transition to the background state.
-        // Use this method to pause ongoing tasks, disable timers, and invalidate graphics rendering callbacks. Games should use this method to pause the game.
-    }
-
-    func applicationDidEnterBackground(_ application: UIApplication) {
-        // Use this method to release shared resources, save user data, invalidate timers, and store enough application state information to restore your application to its current state in case it is terminated later.
-        // If your application supports background execution, this method is called instead of applicationWillTerminate: when the user quits.
-    }
-
-    func applicationWillEnterForeground(_ application: UIApplication) {
-        // Called as part of the transition from the background to the active state; here you can undo many of the changes made on entering the background.
-    }
-
-    func applicationDidBecomeActive(_ application: UIApplication) {
-        // Restart any tasks that were paused (or not yet started) while the application was inactive. If the application was previously in the background, optionally refresh the user interface.
-    }
-
-    func applicationWillTerminate(_ application: UIApplication) {
-        // Called when the application is about to terminate. Save data if appropriate. See also applicationDidEnterBackground:.
+    func application(_ application: UIApplication,
+                     configurationForConnecting connectingSceneSession: UISceneSession,
+                     options: UIScene.ConnectionOptions) -> UISceneConfiguration {
+        return UISceneConfiguration(name: "Default Configuration", sessionRole: connectingSceneSession.role)
     }
 }
-

--- a/Example/Source/SceneDelegate.swift
+++ b/Example/Source/SceneDelegate.swift
@@ -1,0 +1,13 @@
+//
+//  SceneDelegate.swift
+//  Example
+//
+//  Created by Kojiro Futamura on 2026/05/25.
+//  Copyright (c) 2026 Gumob. All rights reserved.
+//
+
+import UIKit
+
+class SceneDelegate: UIResponder, UIWindowSceneDelegate {
+    var window: UIWindow?
+}

--- a/Fluidable.xcodeproj/project.pbxproj
+++ b/Fluidable.xcodeproj/project.pbxproj
@@ -16,6 +16,8 @@
 		A70E1246224F550700AD8008 /* NavigationTableViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = DFABE692442A34025E1F0F44 /* NavigationTableViewController.xib */; };
 		A712402F21CE177D00883E13 /* Fluidable.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A71F674521C50EA8007CADA0 /* Fluidable.framework */; };
 		A712404021CE426600883E13 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = A71F67EB21C66248007CADA0 /* AppDelegate.swift */; };
+		A7F26C012F0C000100000001 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7F26C002F0C000100000001 /* SceneDelegate.swift */; };
+		A7F26C022F0C000100000001 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7F26C002F0C000100000001 /* SceneDelegate.swift */; };
 		A71F674F21C50EA8007CADA0 /* Fluidable.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A71F674521C50EA8007CADA0 /* Fluidable.framework */; };
 		A71F675421C50EA8007CADA0 /* EnumSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = A71F675321C50EA8007CADA0 /* EnumSpec.swift */; };
 		A71F67EC21C66248007CADA0 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = A71F67EB21C66248007CADA0 /* AppDelegate.swift */; };
@@ -353,6 +355,7 @@
 		A71F676721C52451007CADA0 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		A71F67E921C66248007CADA0 /* FluidableExample.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = FluidableExample.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		A71F67EB21C66248007CADA0 /* AppDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
+		A7F26C002F0C000100000001 /* SceneDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
 		A71F67F721C6624A007CADA0 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		A71F680721C6624A007CADA0 /* FluidableUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = FluidableUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		A725FB1F21ED670900178F1F /* Buttons.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Buttons.swift; sourceTree = "<group>"; };
@@ -1198,6 +1201,7 @@
 			isa = PBXGroup;
 			children = (
 				A71F67EB21C66248007CADA0 /* AppDelegate.swift */,
+				A7F26C002F0C000100000001 /* SceneDelegate.swift */,
 				A7C7A95421EC93C2000687C9 /* Control */,
 				A7C7A95E21EC93C2000687C9 /* View */,
 				A7C7A94E21EC93C2000687C9 /* Model */,
@@ -1599,6 +1603,7 @@
 				DFABE3D588D52DA0D98549E4 /* AlignedCollectionLayout.swift in Sources */,
 				A725FB2921ED6FBD00178F1F /* AlignedCollectionView.swift in Sources */,
 				A71F67EC21C66248007CADA0 /* AppDelegate.swift in Sources */,
+				A7F26C012F0C000100000001 /* SceneDelegate.swift in Sources */,
 				A725FB2121ED674500178F1F /* Buttons.swift in Sources */,
 				A7C7A98821EC93C2000687C9 /* CollectionCell.swift in Sources */,
 				A7C7A96821EC93C2000687C9 /* Config.swift in Sources */,
@@ -1648,6 +1653,7 @@
 				DFABE996DD1A19EC135F1B78 /* AlignedCollectionLayout.swift in Sources */,
 				A725FB2A21ED6FBD00178F1F /* AlignedCollectionView.swift in Sources */,
 				A712404021CE426600883E13 /* AppDelegate.swift in Sources */,
+				A7F26C022F0C000100000001 /* SceneDelegate.swift in Sources */,
 				A725FB2221ED674700178F1F /* Buttons.swift in Sources */,
 				A7C7A98921EC93C2000687C9 /* CollectionCell.swift in Sources */,
 				A7C7A96921EC93C2000687C9 /* Config.swift in Sources */,

--- a/Fluidable.xcodeproj/xcshareddata/xcschemes/Fluidable.xcscheme
+++ b/Fluidable.xcodeproj/xcshareddata/xcschemes/Fluidable.xcscheme
@@ -102,18 +102,6 @@
             ReferencedContainer = "container:Fluidable.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
-      <AdditionalOptions>
-         <AdditionalOption
-            key = "MallocStackLogging"
-            value = ""
-            isEnabled = "YES">
-         </AdditionalOption>
-         <AdditionalOption
-            key = "PrefersMallocStackLoggingLite"
-            value = ""
-            isEnabled = "YES">
-         </AdditionalOption>
-      </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"

--- a/Fluidable.xcodeproj/xcshareddata/xcschemes/FluidableExample.xcscheme
+++ b/Fluidable.xcodeproj/xcshareddata/xcschemes/FluidableExample.xcscheme
@@ -84,18 +84,6 @@
             ReferencedContainer = "container:Fluidable.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
-      <AdditionalOptions>
-         <AdditionalOption
-            key = "MallocStackLogging"
-            value = ""
-            isEnabled = "YES">
-         </AdditionalOption>
-         <AdditionalOption
-            key = "PrefersMallocStackLoggingLite"
-            value = ""
-            isEnabled = "YES">
-         </AdditionalOption>
-      </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"


### PR DESCRIPTION
Summary:
- Adopt UIScene lifecycle for the example app
- Remove malloc stack logging launch diagnostics from shared schemes

Verification:
- plutil -lint Example/Info.plist
- swiftlint lint Example/Source/AppDelegate.swift Example/Source/SceneDelegate.swift
- git diff --check
- xcodebuild build on iOS 26.5 Simulator
- xcodebuild build-for-testing on iOS 26.5 Simulator
- simctl install/launch on iOS 26.5 iPhone 17