### PR TITLE
fix(ios): prewarm modal blur snapshots

### DIFF
--- a/Sources/View/FluidBackgroundView.swift
+++ b/Sources/View/FluidBackgroundView.swift
@@ -107,7 +107,7 @@ internal class FluidBlurredBackgroundView: UIView, FluidBackgroundCompatible {
     private func applyVisibility() {
         let clampedVisibility = self.visibility.clamped(0, 1)
         self.blurRadius = self.baseBlurRadius * clampedVisibility
-        if clampedVisibility > 0, self.blurView.image == nil {
+        if self.blurView.image == nil {
             self.updateSnapshot()
         }
         self.blurView.alpha = clampedVisibility

--- a/Tests/UIKitSpec.swift
+++ b/Tests/UIKitSpec.swift
@@ -1460,6 +1460,27 @@ final class UIKitSpec: QuickSpec {
                     expect(waitForBlurredImage(in: backgroundView)).notTo(beNil())
                 }
 
+                it("prepares blurred snapshots before becoming visible") {
+                    let container = UIView(frame: CGRect(x: 0, y: 0, width: 200, height: 120))
+                    let window = UIWindow(frame: container.bounds)
+                    let sourceView = UIView(frame: container.bounds)
+                    let backgroundView = FluidBlurredBackgroundView(radius: 20, color: .clear, alpha: 0)
+                    let blurView = backgroundView.subviews.compactMap { $0 as? UIImageView }.first
+
+                    sourceView.backgroundColor = .red
+                    window.addSubview(container)
+                    window.isHidden = false
+                    defer { window.isHidden = true }
+                    container.addSubview(sourceView)
+                    container.addSubview(backgroundView)
+
+                    container.updateConstraintsAndLayoutImmediately()
+
+                    expect(backgroundView.visibility).to(beCloseTo(0))
+                    expect(blurView?.alpha).to(beCloseTo(0))
+                    expect(waitForBlurredImage(in: backgroundView, timeout: 0.5)).notTo(beNil())
+                }
+
                 it("captures background behind transition containers") {
                     let bounds = CGRect(x: 0, y: 0, width: 200, height: 120)
                     let window = UIWindow(frame: bounds)


### PR DESCRIPTION
## Summary
- Prewarm blurred background snapshots before modal visibility becomes nonzero.
- Add regression coverage for hidden blurred backgrounds preparing a snapshot.

## Verification
- git diff --check
- xcodebuild test -project Fluidable.xcodeproj -scheme Fluidable -destination platform=iOS Simulator,id=5F3F8F67-5FEC-459B-AF9B-E7E7D4BCEBBF -only-testing:FluidableTests/UIKitSpec CODE_SIGNING_ALLOWED=NO
- xcodebuild test-without-building via xctestrun shard 0/20 for FluidableUITests/MainSpec, NavigationFluidModal portrait, 3 tests

## UI check
- NavigationFluidModal FinishAnimatedPresent_FinishAnimatedDismissWithBackground: OK
- NavigationFluidModal FinishAnimatedPresent_FinishInteractiveDismiss: OK
- NavigationFluidModal KeepRootNavigationVisibleAndAlignFluidModalContent: OK